### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/server/auth.py
+++ b/server/auth.py
@@ -39,7 +39,13 @@ def register_user(
 ):
     # Load invites
     try:
-        with open(invites_file, "r", encoding="utf-8") as f:
+        # Validate the invites_file path
+        base_path = os.path.dirname(INVITES_FILE)
+        normalized_path = os.path.normpath(invites_file)
+        if not normalized_path.startswith(base_path):
+            raise HTTPException(status_code=400, detail="Invalid file path.")
+
+        with open(normalized_path, "r", encoding="utf-8") as f:
             invites = json.load(f)
     except Exception:
         invites = []
@@ -59,7 +65,13 @@ def register_user(
 
     # Load users
     try:
-        with open(users_file, "r", encoding="utf-8") as f:
+        # Validate the users_file path
+        base_path = os.path.dirname(USERS_FILE)
+        normalized_path = os.path.normpath(users_file)
+        if not normalized_path.startswith(base_path):
+            raise HTTPException(status_code=400, detail="Invalid file path.")
+
+        with open(normalized_path, "r", encoding="utf-8") as f:
             users = json.load(f)
     except Exception:
         users = []


### PR DESCRIPTION
Potential fix for [https://github.com/arkanwolfshade/MythosMUD/security/code-scanning/1](https://github.com/arkanwolfshade/MythosMUD/security/code-scanning/1)

To address the issue, we will validate the `invites_file` path to ensure it is within a safe directory. Specifically, we will:
1. Normalize the `invites_file` path using `os.path.normpath` to eliminate any `..` segments.
2. Verify that the normalized path starts with the directory containing the `INVITES_FILE` constant. This ensures that the file path is restricted to the intended directory.

These changes will be applied to the `register_user` function, where the `invites_file` parameter is used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
