### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/server/auth.py
+++ b/server/auth.py
@@ -40,10 +40,12 @@ def register_user(
     # Load invites
     try:
         # Validate the invites_file path
-        base_path = os.path.dirname(INVITES_FILE)
-        normalized_path = os.path.normpath(invites_file)
+        base_path = os.path.realpath(os.path.dirname(INVITES_FILE))
+        normalized_path = os.path.realpath(invites_file)
         if not normalized_path.startswith(base_path):
-            raise HTTPException(status_code=400, detail="Invalid file path.")
+            normalized_path = INVITES_FILE  # Fallback to default
+
+        with open(normalized_path, "r", encoding="utf-8") as f:
 
         with open(normalized_path, "r", encoding="utf-8") as f:
             invites = json.load(f)
@@ -66,10 +68,12 @@ def register_user(
     # Load users
     try:
         # Validate the users_file path
-        base_path = os.path.dirname(USERS_FILE)
-        normalized_path = os.path.normpath(users_file)
+        base_path = os.path.realpath(os.path.dirname(USERS_FILE))
+        normalized_path = os.path.realpath(users_file)
         if not normalized_path.startswith(base_path):
-            raise HTTPException(status_code=400, detail="Invalid file path.")
+            normalized_path = USERS_FILE  # Fallback to default
+
+        with open(normalized_path, "r", encoding="utf-8") as f:
 
         with open(normalized_path, "r", encoding="utf-8") as f:
             users = json.load(f)


### PR DESCRIPTION
Potential fix for [https://github.com/arkanwolfshade/MythosMUD/security/code-scanning/3](https://github.com/arkanwolfshade/MythosMUD/security/code-scanning/3)

To fix the issue, we will:
1. Strengthen the validation logic for `users_file` and `invites_file` to ensure they are strictly controlled and cannot be overridden with unsafe values.
2. Use `os.path.realpath` instead of `os.path.normpath` to resolve symbolic links and ensure the path is canonicalized before validation.
3. Add a fallback mechanism to enforce the use of the default file paths (`USERS_FILE` and `INVITES_FILE`) if the dependency injection mechanism is overridden with unsafe values.

The changes will be made in the `register_user` function to ensure that both `users_file` and `invites_file` are validated and sanitized before use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
