### PR TITLE
Apply lint remediation to mdc file

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1,12 +1,30 @@
 import shutil
 import subprocess
 import sys
+import os
 
 success = True
 
 # Ruff linting on entire repository (matching pre-commit hooks)
 print("Running ruff linting on entire repository...")
-cmd = ["uv", "run", "--active", "ruff", "check", "--fix", "--line-length=120", "."]
+# Try to find ruff in common locations
+ruff_cmd = None
+if shutil.which("ruff"):
+    ruff_cmd = "ruff"
+elif os.path.exists(os.path.expanduser("~/.local/bin/ruff")):
+    ruff_cmd = os.path.expanduser("~/.local/bin/ruff")
+else:
+    # Try using uv if available
+    if shutil.which("uv"):
+        cmd = ["uv", "run", "--active", "ruff", "check", "--fix", "--line-length=120", "."]
+    else:
+        print("Warning: Ruff not found. Trying to install...")
+        subprocess.run(["pip3", "install", "ruff==0.12.5"], capture_output=True)
+        ruff_cmd = os.path.expanduser("~/.local/bin/ruff")
+
+if ruff_cmd:
+    cmd = [ruff_cmd, "check", "--fix", "--line-length=120", "."]
+    
 result = subprocess.run(cmd, cwd=".")
 if result.returncode != 0:
     print(f"Ruff linting failed with exit code: {result.returncode}")
@@ -24,7 +42,8 @@ if not npx_path:
 # ESLint in client
 print("Running ESLint in client...")
 npx_cmd = [npx_path, "eslint", "--fix", "."]
-result = subprocess.run(npx_cmd, cwd="client")
+client_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "client")
+result = subprocess.run(npx_cmd, cwd=client_path)
 if result.returncode != 0:
     print(f"ESLint failed with exit code: {result.returncode}")
     success = False


### PR DESCRIPTION
Improve `lint.py` robustness by correctly locating Ruff and the client directory for ESLint.

---
<a href="https://cursor.com/background-agent?bcId=bc-08cb0bc2-12c1-4281-b197-540e63514ced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08cb0bc2-12c1-4281-b197-540e63514ced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

