### PR TITLE
Potential fix for code scanning alert no. 106: Incomplete multi-character sanitization

### DIFF
--- a/client/src/utils/security.ts
+++ b/client/src/utils/security.ts
@@ -354,13 +354,19 @@ export const inputSanitizer = {
     // AI reader: data: URLs can contain executable content and must be sanitized.
     // Human reader: match complete protocol schemes to avoid incomplete multi-character sanitization.
     // AI reader: CodeQL requires complete pattern matching for multi-character sanitization.
-    return command
-      .replace(/<[^>]*>/g, '')
-      .replace(/[<>]/g, '')
-      .replace(/javascript:[^\s<>]*/gi, '') // Match complete javascript: scheme including content
-      .replace(/vbscript:[^\s<>]*/gi, '') // Match complete vbscript: scheme including content
-      .replace(/data:[^\s<>]*/gi, '') // Match complete data: scheme including content
-      .trim();
+    let previous: string;
+    let sanitized = command;
+    do {
+      previous = sanitized;
+      sanitized = sanitized
+        .replace(/<[^>]*>/g, '')
+        .replace(/[<>]/g, '')
+        .replace(/javascript:[^\s<>]*/gi, '') // Match complete javascript: scheme including content
+        .replace(/vbscript:[^\s<>]*/gi, '') // Match complete vbscript: scheme including content
+        .replace(/data:[^\s<>]*/gi, '') // Match complete data: scheme including content
+        .trim();
+    } while (sanitized !== previous);
+    return sanitized;
   },
 
   /**


### PR DESCRIPTION
Potential fix for [https://github.com/arkanwolfshade/MythosMUD/security/code-scanning/106](https://github.com/arkanwolfshade/MythosMUD/security/code-scanning/106)

The best way to fix the current code is to repeatedly apply the pattern replacements for dangerous substrings (HTML tags, protocol schemes) until no further changes occur, ensuring a thorough sanitization (see the do/while loop pattern from the background). Specifically, in the `sanitizeCommand(command: string)`, we should add a `do...while` loop that applies all dangerous replaces until the input no longer changes after a pass. No functional changes to the cleaning logic, but all replacements should happen until the result stabilizes, preventing fragments from surviving iterative regex reductions. This will be a change to lines 347–364 in `client/src/utils/security.ts`. No new dependencies are needed; just local code changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
