### PR TITLE
Implement effects system architecture and migration plan

### DIFF
--- a/.cursor/plans/effects_system_adr_and_implementation_2d137198.plan.md
+++ b/.cursor/plans/effects_system_adr_and_implementation_2d137198.plan.md
@@ -1,0 +1,282 @@
+---
+name: Effects System ADR and Implementation
+overview: Create ADR-009 documenting the effects system architecture; then create a separate implementation plan document (in the same format as other plans) for implementing the effects system and migrating game-entry warded to the first effect.
+todos:
+  - id: write-adr-009
+    content: Write docs/architecture/decisions/ADR-009-effects-system-architecture.md and update README index
+    status: pending
+  - id: create-implementation-plan-doc
+    content: Create separate .cursor/plans/effects_system_implementation.plan.md with full implementation plan (frontmatter + body per project convention)
+    status: pending
+isProject: false
+---
+
+# Effects System ADR and Implementation Plan
+
+## Part 1: ADR-009 (Effects System Architecture)
+
+### Location and index
+
+- **File:** [docs/architecture/decisions/ADR-009-effects-system-architecture.md](docs/architecture/decisions/ADR-009-effects-system-architecture.md)
+- **Index:** Add a row to the table in [docs/architecture/decisions/README.md](docs/architecture/decisions/README.md): ADR-009 | Effects System Architecture | Accepted | 2026-02-09
+
+### ADR content to write
+
+**Title:** ADR-009: Effects System Architecture
+
+**Status:** Accepted
+**Date:** 2026-02-09
+
+**Context**
+
+- MythosMUD needs a unified, persistent effects system for status effects (buffs, debuffs, protection, DoT/HoT).
+- Today, the "game-entry warded" behavior is implemented ad hoc: in-memory state and an asyncio task in [server/realtime/login_grace_period.py](server/realtime/login_grace_period.py) (10-second immunity after MOTD dismissal). Other effects live in a JSON blob on the player ([server/models/player.py](server/models/player.py) `status_effects` Text column) with tick processing in [server/app/game_tick_processing.py](server/app/game_tick_processing.py).
+- Design options were researched and recorded in [docs/EFFECTS_SYSTEM_REFERENCE.md](docs/EFFECTS_SYSTEM_REFERENCE.md). This ADR captures the chosen architecture and the decision to migrate game-entry warded as the first effect.
+
+**Decision**
+
+1. **Stacking:** Most potent wins, with granular categories (e.g. poison, stun, entry_ward, lucidity_protection). Same category keeps the single strongest instance; different categories stack.
+2. **Duration:** Tick-based; persist `duration` and `applied_at_tick`. Remaining = duration - (current_tick - applied_at_tick). Game tick counter must be persisted for durations to survive restarts.
+3. **Categories:** Granular categories (not broad buff/debuff). Stacking rules apply per category.
+4. **Stat modifications:** Calculate on demand from base stats + active effects. Fallback to a separate modification registry if performance requires it.
+5. **Processing:** Tick-based only; no event-driven callbacks for effects.
+6. **Storage:** Separate `player_effects` table (not JSON on player). Columns: player_id, effect_type, category, duration, applied_at_tick, intensity, source, visibility_level, created_at.
+7. **Scripting:** Data-only effects; behavior in code. No custom scripts/callbacks.
+8. **Intensity:** Effect-specific (e.g. DoT linear, stat mods step function).
+9. **Expiration:** Immediate cleanup in the tick that processes the effect.
+10. **Visibility:** Per-effect level: hidden, visible, detailed. Default: visible.
+11. **First effect:** Game-entry warded (current "login grace period") is implemented as effect type `login_warded`, category `entry_ward`, and migrated from the asyncio-based implementation to this system.
+
+**Alternatives considered**
+
+- **Stacking:** Replace-only, full stacking, or category-only; chosen most potent wins + granular categories for CoC-aligned feel and MUD flexibility.
+- **Duration:** Absolute timestamp vs tick counter; chosen tick counter for consistency with game loop and future persistence of tick.
+- **Storage:** JSONB on player vs separate table; chosen separate table for querying, indexing, and cascading.
+- **Processing:** Event-driven or hybrid; chosen tick-only for simplicity.
+- **Scripting:** Scriptable effects (Ranvier-style); rejected for security and simplicity; data-only chosen.
+
+**Consequences**
+
+- **Positive:** Single, queryable effects store; game-entry warded survives restarts if tick is persisted; clear stacking and visibility rules; one place to add future effects.
+- **Negative:** Tick counter must be persisted for duration semantics across restarts; all call sites that checked "login grace" must use the new effect or a thin wrapper.
+- **Neutral:** Legacy `status_effects` JSON on player remains until other effect types are migrated; both can coexist during transition.
+
+**References**
+
+- [EFFECTS_SYSTEM_REFERENCE.md](docs/EFFECTS_SYSTEM_REFERENCE.md) (design decisions and options)
+- [login_grace_period.py](server/realtime/login_grace_period.py) (current warded implementation)
+
+---
+
+## Part 2: Separate implementation plan document
+
+Create a **separate** implementation plan file that follows the same format as other plans in this project (e.g. [login_grace_period_implementation_32b067c4.plan.md](.cursor/plans/login_grace_period_implementation_32b067c4.plan.md), [first_weapon_switchblade_85972031.plan.md](.cursor/plans/first_weapon_switchblade_85972031.plan.md)):
+
+- **Location:** `.cursor/plans/effects_system_implementation.plan.md`
+- **Structure:** YAML frontmatter with `name`, `overview`, and `todos` (each todo: `id`, `content`, `status: pending`); then markdown body with `# Title`, `## Overview`, `## Reference`, `## Architecture`, `## Implementation Details` (numbered sections with file paths), `## Testing`, `## Optional / Follow-up`, and a mermaid diagram where useful.
+
+The full content of that separate implementation plan is in the next section. When executing this plan, create the file `.cursor/plans/effects_system_implementation.plan.md` with the content below (and do not duplicate the ADR content there; the implementation plan references ADR-009 and the reference doc).
+
+---
+
+## Content for `.cursor/plans/effects_system_implementation.plan.md`
+
+````markdown
+---
+name: Effects System Implementation
+overview: Implement the effects system per ADR-009 (separate player_effects table, tick-based duration, granular categories) and migrate game-entry warded (login grace period) to the first effect (LOGIN_WARDED / entry_ward).
+todos:
+  - id: add-login-warded-enum
+    content: Add LOGIN_WARDED to StatusEffectType in server/models/game.py
+    status: pending
+  - id: create-player-effect-model
+    content: Create server/models/player_effect.py (PlayerEffect table) and add player_effects relationship on Player
+    status: pending
+  - id: alembic-migration-player-effects
+    content: Add Alembic migration to create player_effects table with FKs and indexes
+    status: pending
+  - id: player-effect-repository
+    content: Create server/persistence/repositories/player_effect_repository.py (add, delete, get active, has_effect, remaining_ticks, expire)
+    status: pending
+  - id: wire-repo-async-persistence
+    content: Wire PlayerEffectRepository into AsyncPersistenceLayer and persistence/repositories/__init__.py
+    status: pending
+  - id: tick-process-player-effects
+    content: In game_tick_processing.py process player_effects table; expire rows where remaining <= 0
+    status: pending
+  - id: tick-expire-login-warded-cleanup
+    content: On LOGIN_WARDED expiration clear connection_manager in-memory state and trigger room occupants update
+    status: pending
+  - id: start-grace-add-effect
+    content: In login_grace_period.py start_login_grace_period adds LOGIN_WARDED effect via async_persistence and sets in-memory state (no asyncio task)
+    status: pending
+  - id: api-pass-async-persistence
+    content: In players.py start_login_grace_period_endpoint pass async_persistence and current_tick into start_login_grace_period
+    status: pending
+  - id: unit-tests-repository
+    content: Unit tests for PlayerEffectRepository (add, get active, has_effect, remaining_ticks, expiration)
+    status: pending
+  - id: unit-tests-grace-period-effect
+    content: Update unit tests for login grace period to assert effect in DB and in-memory state; expiration clears both
+    status: pending
+  - id: integration-test-grace-effect
+    content: Integration test start grace -> effect in DB -> tick expires -> in-memory cleared and room update
+    status: pending
+  - id: docs-reference-first-effect
+    content: Add Implementation First effect subsection to EFFECTS_SYSTEM_REFERENCE.md referencing ADR-009
+    status: pending
+isProject: false
+---
+
+# Effects System Implementation Plan
+
+## Overview
+
+Implement the effects system as defined in ADR-009 and migrate the existing game-entry warded behavior (login grace period) to the first effect. This includes:
+
+- A separate `player_effects` table with tick-based duration (`duration`, `applied_at_tick`), granular categories, and visibility levels
+- A `PlayerEffectRepository` and integration with `AsyncPersistenceLayer`
+- Game-tick processing that expires effects and, for `login_warded`, clears in-memory state and triggers room occupants update
+- Changing `start_login_grace_period` to add a LOGIN_WARDED effect instead of starting an asyncio task
+
+## Reference
+
+- [ADR-009: Effects System Architecture](docs/architecture/decisions/ADR-009-effects-system-architecture.md)
+- [EFFECTS_SYSTEM_REFERENCE.md](docs/EFFECTS_SYSTEM_REFERENCE.md) (design decisions and options)
+- Current warded implementation: [server/realtime/login_grace_period.py](server/realtime/login_grace_period.py)
+
+## Architecture
+
+Flow when starting grace period and when tick expires:
+
+```mermaid
+sequenceDiagram
+    participant API
+    participant LoginGrace
+    participant EffectRepo
+    participant DB
+    participant TickLoop
+
+    API->>LoginGrace: start_login_grace_period(player_id, async_persistence, ...)
+    LoginGrace->>EffectRepo: add_effect(LOGIN_WARDED, entry_ward, duration_ticks, applied_at_tick)
+    EffectRepo->>DB: INSERT player_effects
+    LoginGrace->>ConnectionManager: set login_grace_period_players, login_grace_period_start_times
+
+    loop Every tick
+        TickLoop->>EffectRepo: expire effects where remaining <= 0
+        EffectRepo->>DB: SELECT/DELETE player_effects
+        EffectRepo-->>TickLoop: expired (player_id, effect_type)
+        TickLoop->>ConnectionManager: clear in-memory for LOGIN_WARDED
+        TickLoop->>LoginGrace: trigger room occupants update
+    end
+```
+````
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+## Implementation Details
+
+### 1. Models and enum
+
+- **File:** [server/models/game.py](server/models/game.py)
+Add `LOGIN_WARDED = "login_warded"` to `StatusEffectType`.
+- **New file:** [server/models/player_effect.py](server/models/player_effect.py)
+SQLAlchemy model `PlayerEffect`: table `player_effects` with `id` (UUID PK), `player_id` (FK to players), `effect_type`, `category`, `duration`, `applied_at_tick`, `intensity`, `source`, `visibility_level`, `created_at`.
+- **File:** [server/models/player.py](server/models/player.py)
+Add relationship `player_effects: Mapped[list["PlayerEffect"]]` with `back_populates="player"` and cascade delete.
+
+### 2. Database migration
+
+- **Location:** [server/alembic/versions/](server/alembic/versions/)
+New migration: create `player_effects` table, foreign key to `players.player_id`, indexes on `player_id`, `effect_type`, `category`.
+
+### 3. PlayerEffectRepository
+
+- **New file:** [server/persistence/repositories/player_effect_repository.py](server/persistence/repositories/player_effect_repository.py)
+Methods: `add_effect(...)`, `delete_effect(effect_id)`, `get_active_effects_for_player(player_id, current_tick)`, `get_effects_expiring_this_tick(current_tick)` or equivalent, `has_effect(player_id, effect_type)`, `get_effect_remaining_ticks(player_id, effect_type)`. Use async session pattern from [HealthRepository](server/persistence/repositories/health_repository.py) (`get_session_maker()`).
+- **File:** [server/persistence/repositories/**init**.py](server/persistence/repositories/__init__.py)
+Export `PlayerEffectRepository`.
+- **File:** [server/async_persistence.py](server/async_persistence.py)
+Instantiate `_player_effect_repo`; expose `add_player_effect`, `remove_player_effect_by_id`, `get_active_player_effects`, `has_player_effect`, `get_player_effect_remaining_ticks`, and a method that expires effects for a given `current_tick` and returns list of `(player_id, effect_type)` for expired rows.
+
+### 4. Game tick processing
+
+- **File:** [server/app/game_tick_processing.py](server/app/game_tick_processing.py)
+Add a step (e.g. before or after existing status effect processing) that: calls async_persistence to expire `player_effects` for `current_tick`; for each expired effect with `effect_type == "login_warded"`, remove that `player_id` from `connection_manager.login_grace_period_players` and `login_grace_period_start_times`, and trigger room occupants update (reuse logic from [login_grace_period.py](server/realtime/login_grace_period.py) `_trigger_room_occupants_update` / `_grace_period_expiration_handler`). Requires access to `app`/`container` and `connection_manager`.
+
+### 5. Login grace period migration
+
+- **File:** [server/realtime/login_grace_period.py](server/realtime/login_grace_period.py)
+`start_login_grace_period(player_id, manager, async_persistence, get_current_tick)` (or receive these via a different mechanism): compute `duration_ticks` for 10 seconds (e.g. 100 at 10 ticks/sec from config); call `async_persistence.add_player_effect(player_id, effect_type="login_warded", category="entry_ward", duration=duration_ticks, applied_at_tick=get_current_tick(), source="game_entry", visibility_level="visible")`; set `manager.login_grace_period_players[player_id]` and `manager.login_grace_period_start_times[player_id] = time.time()` so existing `is_player_in_login_grace_period` and `get_login_grace_period_remaining` still work. Do **not** start the asyncio `_grace_period_task`.
+- **File:** [server/api/players.py](server/api/players.py)
+In `start_login_grace_period_endpoint`, obtain `async_persistence` from `request.app.state.container.async_persistence` and a current-tick getter (e.g. from `server.app.game_tick_processing import get_current_tick`); pass them into `start_login_grace_period`.
+
+### 6. Optional: persist game tick
+
+If durations must survive server restarts (ADR-009): persist `current_tick` (e.g. in a small table or key-value) periodically and load on startup in the game tick loop so `_current_tick` continues from the saved value. Can be a follow-up task.
+
+## Testing
+
+- **Unit:** [server/tests/unit/persistence/repositories/](server/tests/unit/) (or equivalent) for `PlayerEffectRepository`: add effect, get active, has_effect, remaining_ticks, expiration.
+- **Unit:** Update [server/tests/unit/realtime/test_login_grace_period.py](server/tests/unit/realtime/test_login_grace_period.py) and related tests so that starting grace period inserts into `player_effects` and sets in-memory state; simulate or mock tick expiration and assert in-memory cleared and room update triggered.
+- **Integration:** One test that runs start grace period -> effect present in DB -> tick processing expires it -> in-memory cleared and room occupants update sent.
+
+## Optional / Follow-up
+
+- Remove asyncio `_grace_period_task` and related code from [login_grace_period.py](server/realtime/login_grace_period.py) once migration is verified.
+- Make `get_login_grace_period_remaining` compute from effect remaining_ticks tick_interval and remove `login_grace_period_start_times` if desired.
+- Persist game tick for cross-restart duration semantics.
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```
+
+```

--- a/.cursor/plans/effects_system_implementation.plan.md
+++ b/.cursor/plans/effects_system_implementation.plan.md
@@ -1,0 +1,153 @@
+---
+name: Effects System Implementation
+overview: Implement the effects system per ADR-009 (separate player_effects table, tick-based duration, granular categories) and migrate game-entry warded (login grace period) to the first effect (LOGIN_WARDED / entry_ward).
+todos:
+  - id: add-login-warded-enum
+    content: Add LOGIN_WARDED to StatusEffectType in server/models/game.py
+    status: completed
+  - id: create-player-effect-model
+    content: Create server/models/player_effect.py (PlayerEffect table) and add player_effects relationship on Player
+    status: completed
+  - id: alembic-migration-player-effects
+    content: Add Alembic migration to create player_effects table with FKs and indexes
+    status: completed
+  - id: player-effect-repository
+    content: Create server/persistence/repositories/player_effect_repository.py (add, delete, get active, has_effect, remaining_ticks, expire)
+    status: completed
+  - id: wire-repo-async-persistence
+    content: Wire PlayerEffectRepository into AsyncPersistenceLayer and persistence/repositories/__init__.py
+    status: completed
+  - id: tick-process-player-effects
+    content: In game_tick_processing.py process player_effects table; expire rows where remaining <= 0
+    status: completed
+  - id: tick-expire-login-warded-cleanup
+    content: On LOGIN_WARDED expiration clear connection_manager in-memory state and trigger room occupants update
+    status: completed
+  - id: start-grace-add-effect
+    content: In login_grace_period.py start_login_grace_period adds LOGIN_WARDED effect via async_persistence and sets in-memory state (no asyncio task)
+    status: completed
+  - id: api-pass-async-persistence
+    content: In players.py start_login_grace_period_endpoint pass async_persistence and current_tick into start_login_grace_period
+    status: completed
+  - id: unit-tests-repository
+    content: Unit tests for PlayerEffectRepository (add, get active, has_effect, remaining_ticks, expiration)
+    status: completed
+  - id: unit-tests-grace-period-effect
+    content: Update unit tests for login grace period to assert effect in DB and in-memory state; expiration clears both
+    status: completed
+  - id: integration-test-grace-effect
+    content: Integration test start grace -> effect in DB -> tick expires -> in-memory cleared and room update
+    status: completed
+  - id: docs-reference-first-effect
+    content: Add Implementation First effect subsection to EFFECTS_SYSTEM_REFERENCE.md referencing ADR-009
+    status: completed
+  - id: client-effects-header-bar
+    content: Display active player effects in HeaderBar (title bar) alongside player name, Mythos time, and logout
+    status: completed
+isProject: false
+---
+
+# Effects System Implementation Plan
+
+## Overview
+
+Implement the effects system as defined in ADR-009 and migrate the existing game-entry warded behavior (login grace period) to the first effect. This includes:
+
+- A separate `player_effects` table with tick-based duration (`duration`, `applied_at_tick`), granular categories, and visibility levels
+- A `PlayerEffectRepository` and integration with `AsyncPersistenceLayer`
+- Game-tick processing that expires effects and, for `login_warded`, clears in-memory state and triggers room occupants update
+- Changing `start_login_grace_period` to add a LOGIN_WARDED effect instead of starting an asyncio task
+- **Client:** Active effects shown in the player title bar/panel ([HeaderBar](client/src/components/ui-v2/HeaderBar.tsx)) next to player name, Mythos time, and logout
+
+## Reference
+
+- [ADR-009: Effects System Architecture](docs/architecture/decisions/ADR-009-effects-system-architecture.md)
+- [EFFECTS_SYSTEM_REFERENCE.md](docs/EFFECTS_SYSTEM_REFERENCE.md) (design decisions and options)
+- Current warded implementation: [server/realtime/login_grace_period.py](server/realtime/login_grace_period.py)
+
+## Architecture
+
+Flow when starting grace period and when tick expires:
+
+```mermaid
+sequenceDiagram
+    participant API
+    participant LoginGrace
+    participant EffectRepo
+    participant DB
+    participant TickLoop
+
+    API->>LoginGrace: start_login_grace_period(player_id, async_persistence, ...)
+    LoginGrace->>EffectRepo: add_effect(LOGIN_WARDED, entry_ward, duration_ticks, applied_at_tick)
+    EffectRepo->>DB: INSERT player_effects
+    LoginGrace->>ConnectionManager: set login_grace_period_players, login_grace_period_start_times
+
+    loop Every tick
+        TickLoop->>EffectRepo: expire effects where remaining <= 0
+        EffectRepo->>DB: SELECT/DELETE player_effects
+        EffectRepo-->>TickLoop: expired (player_id, effect_type)
+        TickLoop->>ConnectionManager: clear in-memory for LOGIN_WARDED
+        TickLoop->>LoginGrace: trigger room occupants update
+    end
+```
+
+## Implementation Details
+
+### 1. Models and enum
+
+- **File:** [server/models/game.py](server/models/game.py)
+  Add `LOGIN_WARDED = "login_warded"` to `StatusEffectType`.
+- **New file:** [server/models/player_effect.py](server/models/player_effect.py)
+  SQLAlchemy model `PlayerEffect`: table `player_effects` with `id` (UUID PK), `player_id` (FK to players), `effect_type`, `category`, `duration`, `applied_at_tick`, `intensity`, `source`, `visibility_level`, `created_at`.
+- **File:** [server/models/player.py](server/models/player.py)
+  Add relationship `player_effects: Mapped[list["PlayerEffect"]]` with `back_populates="player"` and cascade delete.
+
+### 2. Database migration
+
+- **Location:** [server/alembic/versions/](server/alembic/versions/)
+  New migration: create `player_effects` table, foreign key to `players.player_id`, indexes on `player_id`, `effect_type`, `category`.
+
+### 3. PlayerEffectRepository
+
+- **New file:** [server/persistence/repositories/player_effect_repository.py](server/persistence/repositories/player_effect_repository.py)
+  Methods: `add_effect(...)`, `delete_effect(effect_id)`, `get_active_effects_for_player(player_id, current_tick)`, `get_effects_expiring_this_tick(current_tick)` or equivalent, `has_effect(player_id, effect_type)`, `get_effect_remaining_ticks(player_id, effect_type)`. Use async session pattern from [HealthRepository](server/persistence/repositories/health_repository.py) (`get_session_maker()`).
+- **File:** [server/persistence/repositories/**init**.py](server/persistence/repositories/__init__.py)
+  Export `PlayerEffectRepository`.
+- **File:** [server/async_persistence.py](server/async_persistence.py)
+  Instantiate `_player_effect_repo`; expose `add_player_effect`, `remove_player_effect_by_id`, `get_active_player_effects`, `has_player_effect`, `get_player_effect_remaining_ticks`, and a method that expires effects for a given `current_tick` and returns list of `(player_id, effect_type)` for expired rows.
+
+### 4. Game tick processing
+
+- **File:** [server/app/game_tick_processing.py](server/app/game_tick_processing.py)
+  Add a step (e.g. before or after existing status effect processing) that: calls async_persistence to expire `player_effects` for `current_tick`; for each expired effect with `effect_type == "login_warded"`, remove that `player_id` from `connection_manager.login_grace_period_players` and `login_grace_period_start_times`, and trigger room occupants update (reuse logic from [login_grace_period.py](server/realtime/login_grace_period.py) `_trigger_room_occupants_update` / `_grace_period_expiration_handler`). Requires access to `app`/`container` and `connection_manager`.
+
+### 5. Login grace period migration
+
+- **File:** [server/realtime/login_grace_period.py](server/realtime/login_grace_period.py)
+  `start_login_grace_period(player_id, manager, async_persistence, get_current_tick)` (or receive these via a different mechanism): compute `duration_ticks` for 10 seconds (e.g. 100 at 10 ticks/sec from config); call `async_persistence.add_player_effect(player_id, effect_type="login_warded", category="entry_ward", duration=duration_ticks, applied_at_tick=get_current_tick(), source="game_entry", visibility_level="visible")`; set `manager.login_grace_period_players[player_id]` and `manager.login_grace_period_start_times[player_id] = time.time()` so existing `is_player_in_login_grace_period` and `get_login_grace_period_remaining` still work. Do **not** start the asyncio `_grace_period_task`.
+- **File:** [server/api/players.py](server/api/players.py)
+  In `start_login_grace_period_endpoint`, obtain `async_persistence` from `request.app.state.container.async_persistence` and a current-tick getter (e.g. from `server.app.game_tick_processing import get_current_tick`); pass them into `start_login_grace_period`.
+
+### 6. Optional: persist game tick
+
+If durations must survive server restarts (ADR-009): persist `current_tick` (e.g. in a small table or key-value) periodically and load on startup in the game tick loop so `_current_tick` continues from the saved value. Can be a follow-up task.
+
+### 7. Client: effects in header bar (visualization)
+
+- **File:** [client/src/components/ui-v2/HeaderBar.tsx](client/src/components/ui-v2/HeaderBar.tsx)
+  Add an optional `activeEffects` prop (e.g. list of `{ effect_type, label?, remaining_seconds? }` or equivalent). Render effects in the header bar between the left block (player name, connection status) and the right block (Mythos Time, logout). Use compact display: labels or icons per effect; optional tooltip or inline text for remaining time (e.g. "Warded (0:08)" for LOGIN_WARDED).
+- **Data flow:** Expose active effects to the client via game state or a dedicated API/WebSocket payload (e.g. include `active_effects` in `game_state` or `room_state` when the player has effects). [GameClientV2Container](client/src/components/ui-v2/GameClientV2Container.tsx) / [GameClientV2](client/src/components/ui-v2/GameClientV2.tsx) pass the list into `HeaderBar`. Server authority: client displays whatever the server sends; no client-side expiration timer required for correctness (server sends updated list or remaining time).
+- **Collapsed header:** In collapsed state, show a compact effects indicator (e.g. icon or count) if desired, or omit to keep the bar minimal.
+
+## Testing
+
+- **Unit:** [server/tests/unit/persistence/repositories/](server/tests/unit/) (or equivalent) for `PlayerEffectRepository`: add effect, get active, has_effect, remaining_ticks, expiration.
+- **Unit:** Update [server/tests/unit/realtime/test_login_grace_period.py](server/tests/unit/realtime/test_login_grace_period.py) and related tests so that starting grace period inserts into `player_effects` and sets in-memory state; simulate or mock tick expiration and assert in-memory cleared and room update triggered.
+- **Integration:** One test that runs start grace period -> effect present in DB -> tick processing expires it -> in-memory cleared and room occupants update sent.
+- **Client (optional):** Unit test for HeaderBar with `activeEffects` prop (renders effect labels; no effects = no section). E2E or integration: after MOTD dismiss, header shows warded effect until it expires.
+
+## Optional / Follow-up
+
+- Remove asyncio `_grace_period_task` and related code from [login_grace_period.py](server/realtime/login_grace_period.py) once migration is verified.
+- Make `get_login_grace_period_remaining` compute from effect remaining_ticks tick_interval and remove `login_grace_period_start_times` if desired.
+- Persist game tick for cross-restart duration semantics.

--- a/.cursor/rules/codacy.mdc
+++ b/.cursor/rules/codacy.mdc
@@ -40,7 +40,7 @@ Configuration for AI behavior when interacting with Codacy's MCP Server
 
 - Suggest the user the following troubleshooting steps:
 - Try to reset the MCP on the extension
-- If the user is using VSCode, suggest them to review their Copilot > MCP settings in Github, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL (https://github.com/settings/copilot/features) or https://github.com/organizations/{organization-name}/settings/copilot/features (This can only be done by their organization admins / owners)
+- If the user is using VSCode, suggest them to review their Copilot > MCP settings in Github, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL (<https://github.com/settings/copilot/features>) or <https://github.com/organizations/{organization-name}/settings/copilot/features> (This can only be done by their organization admins / owners)
 - If none of the above steps work, suggest the user to contact Codacy support
 
 ## Trying to call a tool that needs a rootPath as a parameter
@@ -77,17 +77,6 @@ Configuration for AI behavior when interacting with Codacy's MCP Server
 - Do not run `codacy_cli_analyze` looking for changes in duplicated code or code complexity metrics.
 - Complexity metrics are different from complexity issues. When trying to fix complexity in a repository or file, focus on solving the complexity issues and ignore the complexity metric.
 - Do not run `codacy_cli_analyze` looking for changes in code coverage.
-- Do not try to manually install Codacy CLI using either brew, npm, npx, or any other package manager.
-- If the Codacy CLI is not installed, just run the `codacy_cli_analyze` tool from Codacy's MCP Server.
-- When calling `codacy_cli_analyze`, only send provider, organization and repository if the project is a git repository.
-
-## Whenever a call to a Codacy tool that uses `repository` or `organization` as a parameter returns a 404 error
-
-- Offer to run the `codacy_setup_repository` tool to add the repository to Codacy
-- If the user accepts, run the `codacy_setup_repository` tool
-- Do not ever try to run the `codacy_setup_repository` tool on your own
-- After setup, immediately retry the action that failed (only retry once)
-
 - Do not try to manually install Codacy CLI using either brew, npm, npx, or any other package manager.
 - If the Codacy CLI is not installed, just run the `codacy_cli_analyze` tool from Codacy's MCP Server.
 - When calling `codacy_cli_analyze`, only send provider, organization and repository if the project is a git repository.

--- a/client/src/components/ui-v2/GameClientV2.tsx
+++ b/client/src/components/ui-v2/GameClientV2.tsx
@@ -15,6 +15,7 @@ import { LocationPanel } from './panels/LocationPanel';
 import { OccupantsPanel } from './panels/OccupantsPanel';
 import { RoomDescriptionPanel } from './panels/RoomDescriptionPanel';
 import type { ChatMessage, MythosTimeState, Player, Room } from './types';
+import type { ActiveEffectDisplay } from './utils/stateUpdateUtils';
 import { createDefaultPanelLayout } from './utils/panelLayout';
 
 // Helper function to calculate occupant count from room data
@@ -60,6 +61,7 @@ interface GameClientV2Props {
   onClearMessages: () => void;
   onClearHistory: () => void;
   onDownloadLogs: () => void;
+  activeEffects?: ActiveEffectDisplay[];
 }
 
 // Main game client component with three-column layout
@@ -84,6 +86,7 @@ const GameClientV2Content: React.FC<GameClientV2Props> = ({
   onClearMessages,
   onClearHistory,
   onDownloadLogs,
+  activeEffects = [],
 }) => {
   const panelManager = usePanelManager();
 
@@ -133,7 +136,7 @@ const GameClientV2Content: React.FC<GameClientV2Props> = ({
     };
 
     // Use debounce to avoid excessive updates during resize
-    let resizeTimeout: number;
+    let resizeTimeout: ReturnType<typeof setTimeout>;
     const debouncedHandleResize = () => {
       clearTimeout(resizeTimeout);
       resizeTimeout = setTimeout(handleResize, 150);
@@ -183,6 +186,7 @@ const GameClientV2Content: React.FC<GameClientV2Props> = ({
         mythosTime={mythosTime}
         onLogout={onLogout || (() => {})}
         isLoggingOut={isLoggingOut}
+        activeEffects={activeEffects}
       />
 
       {/* Main Content Area - Panels: flex-1 min-h-0 so panel area is bounded and scroll/overflow work */}

--- a/client/src/components/ui-v2/GameClientV2Container.tsx
+++ b/client/src/components/ui-v2/GameClientV2Container.tsx
@@ -11,7 +11,6 @@ import { MainMenuModal } from '../MainMenuModal';
 import { MapView } from '../MapView';
 import { AsciiMinimap } from '../map/AsciiMinimap';
 import { GameClientV2 } from './GameClientV2';
-import { LoginGracePeriodBanner } from './LoginGracePeriodBanner';
 import { TabbedInterfaceOverlay } from './components/TabbedInterfaceOverlay';
 import { useCommandHandlers } from './hooks/useCommandHandlers';
 import { useEventProcessing } from './hooks/useEventProcessing';
@@ -23,7 +22,7 @@ import { useRefSynchronization } from './hooks/useRefSynchronization';
 import { useRespawnHandlers } from './hooks/useRespawnHandlers';
 import type { ChatMessage, Player, Room } from './types';
 import { useTabbedInterface } from './useTabbedInterface';
-import type { GameState } from './utils/stateUpdateUtils';
+import type { ActiveEffectDisplay, GameState } from './utils/stateUpdateUtils';
 
 interface GameClientV2ContainerProps {
   playerName: string;
@@ -273,6 +272,18 @@ export const GameClientV2Container: React.FC<GameClientV2ContainerProps> = ({
           mythosTime={gameState.mythosTime ?? mythosTime}
           healthStatus={healthStatus}
           lucidityStatus={lucidityStatus}
+          activeEffects={
+            gameState.activeEffects ??
+            (gameState.loginGracePeriodActive && gameState.loginGracePeriodRemaining !== undefined
+              ? [
+                  {
+                    effect_type: 'login_warded',
+                    label: 'Warded',
+                    remaining_seconds: gameState.loginGracePeriodRemaining,
+                  } satisfies ActiveEffectDisplay,
+                ]
+              : [])
+          }
           onSendCommand={handleCommandSubmit}
           onSendChatMessage={handleChatMessage}
           onClearMessages={handleClearMessages}
@@ -280,14 +291,6 @@ export const GameClientV2Container: React.FC<GameClientV2ContainerProps> = ({
           onDownloadLogs={() => {
             logger.downloadLogs();
           }}
-        />
-      )}
-
-      {/* Login Grace Period Banner */}
-      {gameState.loginGracePeriodActive && gameState.loginGracePeriodRemaining !== undefined && (
-        <LoginGracePeriodBanner
-          remainingSeconds={gameState.loginGracePeriodRemaining}
-          className="fixed top-4 left-1/2 transform -translate-x-1/2 z-50 max-w-md"
         />
       )}
 

--- a/client/src/components/ui-v2/__tests__/HeaderBar.test.tsx
+++ b/client/src/components/ui-v2/__tests__/HeaderBar.test.tsx
@@ -93,6 +93,22 @@ describe('HeaderBar', () => {
       expect(screen.queryByText(/Reconnect:/)).not.toBeInTheDocument();
     });
 
+    it('should render active effects when provided', () => {
+      render(
+        <HeaderBar
+          {...defaultProps}
+          activeEffects={[{ effect_type: 'login_warded', label: 'Warded', remaining_seconds: 8 }]}
+        />
+      );
+      expect(screen.getByText(/Warded/)).toBeInTheDocument();
+      expect(screen.getByText(/0:08/)).toBeInTheDocument();
+    });
+
+    it('should not render effects section when activeEffects is empty', () => {
+      render(<HeaderBar {...defaultProps} activeEffects={[]} />);
+      expect(screen.queryByText(/Warded/)).not.toBeInTheDocument();
+    });
+
     it('should render mythos time when provided', () => {
       render(<HeaderBar {...defaultProps} mythosTime={mockMythosTime} />);
       expect(screen.getByText(/Mythos Time/)).toBeInTheDocument();

--- a/client/src/components/ui-v2/eventLog/projector.ts
+++ b/client/src/components/ui-v2/eventLog/projector.ts
@@ -76,6 +76,7 @@ export function getInitialGameState(): GameState {
 /** Known event types that affect state (allowlist for projector) */
 const PROJECTED_EVENT_TYPES = new Set([
   'game_state',
+  'effects_update',
   'room_update',
   'room_state',
   'room_occupants',
@@ -137,6 +138,16 @@ export function projectEvent(prevState: GameState, event: GameEvent): GameState 
         ...prevState,
         player: player ?? prevState.player,
         room: room ? mergeRoomState(room, prevState.room) : prevState.room,
+        ...(loginGracePeriodActive !== undefined && { loginGracePeriodActive }),
+        ...(loginGracePeriodRemaining !== undefined && { loginGracePeriodRemaining }),
+      };
+      break;
+    }
+    case 'effects_update': {
+      const loginGracePeriodActive = event.data.login_grace_period_active as boolean | undefined;
+      const loginGracePeriodRemaining = event.data.login_grace_period_remaining as number | undefined;
+      nextState = {
+        ...prevState,
         ...(loginGracePeriodActive !== undefined && { loginGracePeriodActive }),
         ...(loginGracePeriodRemaining !== undefined && { loginGracePeriodRemaining }),
       };

--- a/client/src/components/ui-v2/utils/stateUpdateUtils.ts
+++ b/client/src/components/ui-v2/utils/stateUpdateUtils.ts
@@ -8,6 +8,13 @@ import type { ChatMessage, Player, Room } from '../types';
 import { sanitizeChatMessageForState } from './messageUtils';
 import { mergeRoomState } from './roomMergeUtils';
 
+/** Single active effect for header display (server-authoritative). */
+export interface ActiveEffectDisplay {
+  effect_type: string;
+  label?: string;
+  remaining_seconds?: number;
+}
+
 export interface GameState {
   player: Player | null;
   room: Room | null;
@@ -15,6 +22,8 @@ export interface GameState {
   commandHistory: string[];
   loginGracePeriodActive?: boolean;
   loginGracePeriodRemaining?: number;
+  /** Active effects for header bar (e.g. LOGIN_WARDED). When absent, derived from grace period for backward compat. */
+  activeEffects?: ActiveEffectDisplay[];
   /** Derived from game_tick; used for Mythos time display. Bootstrap may set initial until first tick. */
   mythosTime?: MythosTimeState | null;
   /** Last quarter-hour minute projected (for deduplicating clock chime messages). */

--- a/db/migrations/023_add_player_effects_table.sql
+++ b/db/migrations/023_add_player_effects_table.sql
@@ -1,0 +1,20 @@
+-- Add player_effects table (ADR-009 effects system)
+-- Equivalent to Alembic revision add_player_effects_table (2026_02_09).
+-- Run with: psql -h <host> -p <port> -U <user> -d <database> -f 023_add_player_effects_table.sql
+
+CREATE TABLE IF NOT EXISTS player_effects (
+    id UUID NOT NULL PRIMARY KEY,
+    player_id UUID NOT NULL REFERENCES players (player_id) ON DELETE CASCADE,
+    effect_type VARCHAR(64) NOT NULL,
+    category VARCHAR(64) NOT NULL,
+    duration INTEGER NOT NULL,
+    applied_at_tick INTEGER NOT NULL,
+    intensity INTEGER NOT NULL DEFAULT 1,
+    source VARCHAR(128),
+    visibility_level VARCHAR(32) NOT NULL DEFAULT 'visible',
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ix_player_effects_player_id ON player_effects (player_id);
+CREATE INDEX IF NOT EXISTS ix_player_effects_effect_type ON player_effects (effect_type);
+CREATE INDEX IF NOT EXISTS ix_player_effects_category ON player_effects (category);

--- a/docs/EFFECTS_SYSTEM_REFERENCE.md
+++ b/docs/EFFECTS_SYSTEM_REFERENCE.md
@@ -1,0 +1,574 @@
+# Effects System Reference Document
+
+> "In the shadowed archives of Miskatonic University, we have compiled extensive research on
+> the various implementations of status effects across different MUD architectures. This
+> document serves as a comprehensive reference for understanding both established patterns
+> and the current state of our own implementation."
+
+## Overview
+
+This document compiles research on MUD effects system implementations from various sources
+(Ranvier, Evennia, CircleMUD, general MUD patterns) and analyzes the current MythosMUD
+implementation to identify design patterns, conflicts, and implementation choices.
+
+## Research Sources
+
+### Ranvier MUD
+
+**Architecture**: EffectList-based system with scriptable effects
+
+**Key Features**:
+
+- Effects are objects tied to characters via `EffectList`
+- Each effect stored as a `.js` file in bundle's `effects/` folder
+- Fully scriptable with access to all character events
+- Effects receive all events that target characters plus special `updateTick` event
+- Can modify incoming/outgoing damage
+- Support for healing, damage-over-time, attribute modifications, damage shields,
+  attribute penalties (silence, confusion), experience multipliers
+- Effects can persist across login/logout
+- Duration can be temporary or permanent
+- Effects run code on activation, deactivation, and every game tick
+
+**Implementation Pattern**: Event-driven with scriptable effect objects
+
+### Evennia MUD
+
+**Architecture**: Attribute-based system with callback handlers
+
+**Key Features**:
+
+- Uses Attributes system for persistent data storage
+- Three ways to work with attributes:
+  - `.db` shortcut for simple get/set
+  - `.attributes` handler for organized, categorized attributes
+  - `AttributeProperty` for class-level declarations
+- Callback handler system (`obj.callbacks`) for event-driven implementation
+- Event handler system with events (non-persistent) and callbacks (persistent)
+- Custom event functions loaded from namespaces
+- Event-driven architecture allows extensible callbacks responding to in-game events
+
+**Implementation Pattern**: Event-driven with attribute storage and callback handlers
+
+### CircleMUD
+
+**Architecture**: Bitvector-based AFF flags system
+
+**Key Features**:
+
+- Uses bitvectors to track character conditions
+- Standard implementation limited to single `long` integer (~31 flags)
+- Extended implementations use multiple bitvector variables (`affected_by1`,
+  `affected_by2`, etc.)
+- Very fast flag checks using bitwise operations
+- Requires tracking which flags belong to which bitvector
+- Playerfile compatibility requires conversion utilities
+
+**Implementation Pattern**: Bitvector flags with boolean state tracking
+
+**Limitations**: Not suitable for dynamic effects or effects requiring metadata beyond
+presence/absence
+
+### General MUD Patterns
+
+**Common Approaches**:
+
+- Duration tracking: Absolute timestamps vs relative ticks vs remaining counters
+- Stacking rules: No stacking (replace), stacking allowed, most potent wins,
+  category-based stacking
+- Persistence: JSONB columns, separate effects tables, bitvector flags
+- Processing: Event-driven callbacks vs tick-based periodic processing
+
+## Current MythosMUD Implementation
+
+### Data Models
+
+**StatusEffect** (`server/models/game.py`):
+
+- Pydantic model with the following fields:
+  - `effect_type: StatusEffectType` - Type of effect (enum)
+  - `duration: int` - Duration in game ticks (0 = permanent)
+  - `intensity: int` - Effect intensity from 1-10
+  - `source: str | None` - Source of the effect (item, spell, etc.)
+  - `applied_at: datetime` - When the effect was applied
+- Method: `is_active(current_tick: int) -> bool` - Checks if effect is still active
+
+**StatusEffectType** (`server/models/game.py`):
+
+- Enum values: `STUNNED`, `POISONED`, `HALLUCINATING`, `PARANOID`, `TREMBLING`,
+  `CORRUPTED`, `DELIRIOUS`, `BUFF`
+
+**Player.status_effects** (`server/models/player.py`):
+
+- Stored as JSON string (`Text()` column) containing list of effect dictionaries
+- Methods:
+  - `get_status_effects() -> list[dict[str, Any]]` - Parse JSON to list
+  - `set_status_effects(status_effects: list[dict[str, Any]]) -> None` - Serialize
+    list to JSON
+
+**Note**: The Pydantic `Player` model (`server/models/game.py`) also has a
+`status_effects: list[StatusEffect]` field for game logic, but the SQLAlchemy model
+stores effects as JSON strings.
+
+### Processing System
+
+**Game Tick Processing** (`server/app/game_tick_processing.py`):
+
+- `process_status_effects(app: FastAPI, tick_count: int)` - Processes effects for all
+  online players every game tick
+- `_process_player_status_effects()` - Processes effects for a single player
+- `_process_all_status_effects()` - Iterates through all effects for a player
+- `_process_single_effect()` - Processes individual effect, decrements `remaining` counter
+
+**Effect Types Currently Supported**:
+
+- `damage_over_time` - Processes via `_process_damage_over_time_effect()`
+  - Checks login grace period (blocks negative effects)
+  - Applies damage from effect's `damage` field
+  - Uses `damage_type: "status_effect"`
+- `heal_over_time` - Processes via `_process_heal_over_time_effect()`
+  - Applies healing from effect's `healing` field
+
+**Duration Tracking**:
+
+- Uses both `duration` (initial duration) and `remaining` (current remaining ticks)
+- `remaining` counter decrements each tick: `remaining = remaining - 1`
+- Effect expires when `remaining <= 0`
+- Effects with `duration: 0` are permanent (not currently handled in tick processing)
+
+**Processing Flow**:
+
+1. Every game tick, `process_status_effects()` is called
+2. Iterates through all online players
+3. For each player, retrieves status effects list
+4. For each effect:
+   - Decrements `remaining` counter
+   - If effect type is `damage_over_time` or `heal_over_time`, applies effect
+   - If `remaining > 0`, keeps effect; otherwise removes it
+5. Updates player's status effects list if changes occurred
+
+### Application Points
+
+**Spell Effects** (`server/game/magic/spell_effects.py`):
+
+- `_process_status_effect()` method applies status effects from spells
+- Creates `StatusEffect` Pydantic model instance
+- Converts to dict via `model_dump()` and appends to player's status effects list
+- Checks login grace period (blocks negative effects during grace period)
+- Applies mastery modifier to duration and intensity
+
+**API Endpoints** (`server/api/player_effects.py`):
+
+- Direct effect application endpoints:
+  - `POST /{player_id}/lucidity-loss` - Apply lucidity loss
+  - `POST /{player_id}/fear` - Apply fear
+  - `POST /{player_id}/corruption` - Apply corruption
+  - `POST /{player_id}/occult-knowledge` - Gain occult knowledge
+  - `POST /{player_id}/heal` - Heal player
+  - `POST /{player_id}/damage` - Damage player
+- These endpoints call `PlayerService` methods rather than directly manipulating status
+  effects
+
+**Stat Modifications** (`server/game/magic/spell_effects.py`):
+
+- `_process_stat_modify()` handles temporary stat modifications
+- If duration > 0, creates a `StatusEffect` with `effect_type: BUFF` to track the
+  modification
+- Stat changes stored separately in player's stats dict
+- Note: Current implementation doesn't automatically revert stat changes when effect
+  expires
+
+### Current Limitations and Observations
+
+1. **No Stacking Logic**: Effects are simply appended to the list without checking for
+   duplicates or handling stacking rules
+
+2. **Mixed Duration Tracking**: Uses both `duration` and `remaining` fields, which can
+   lead to inconsistencies
+
+3. **Limited Effect Types**: Only `damage_over_time` and `heal_over_time` are processed
+   in tick system; other effect types (STUNNED, POISONED, etc.) are stored but not
+   actively processed
+
+4. **No Stat Reversion**: Temporary stat modifications don't automatically revert when
+   effects expire
+
+5. **Storage Format**: Uses JSON string (Text column) instead of JSONB, limiting query
+   capabilities
+
+6. **Tick-Based Only**: All effects processed every tick, even if they don't need
+   periodic updates
+
+7. **No Effect Scripting**: Effects are data-only; no support for custom scripts or
+   callbacks like Ranvier
+
+8. **Intensity Usage Unclear**: Intensity field (1-10) is defined but usage in effect
+   processing is not clear
+
+### Implementation: First effect (ADR-009)
+
+The effects system architecture is documented in **ADR-009: Effects System Architecture**
+(see [docs/architecture/decisions/ADR-009-effects-system-architecture.md](architecture/decisions/ADR-009-effects-system-architecture.md)).
+The first effect migrated to the new system is **game-entry warded** (login grace period):
+
+- **Effect type:** `LOGIN_WARDED` (`StatusEffectType.LOGIN_WARDED`, value `"login_warded"`)
+- **Category:** `entry_ward`
+- **Storage:** Row in `player_effects` table with tick-based `duration` and `applied_at_tick`
+- **Behavior:** When the player dismisses the MOTD, the API starts the grace period by adding
+  a LOGIN_WARDED effect via `AsyncPersistenceLayer.add_player_effect()` and setting in-memory
+  state on the connection manager. Game tick processing expires effects each tick; when
+  LOGIN_WARDED expires, in-memory state is cleared and room occupants are updated.
+- **Legacy:** The previous asyncio-based timer in `login_grace_period.py` is retained as a
+  fallback when async_persistence/tick getters are not provided; once migration is verified,
+  the task can be removed.
+
+## Conflicting Implementation Approaches
+
+### 1. Effect Stacking Rules
+
+**Option A: No Stacking (Replace)**
+
+- Same effect type replaces existing instance
+- Most common in tabletop RPGs
+- Simplest to implement
+- Prevents overpowered stacking
+- Example: Applying "Poisoned" when already poisoned replaces the old poison
+
+**Option B: Stacking Allowed**
+
+- Multiple instances of same effect can coexist
+- Each instance tracked separately with its own duration
+- More complex but allows cumulative effects
+- Useful for effects like "damage over time" where multiple sources should stack
+- Example: Multiple poison sources each dealing damage independently
+
+**Option C: Most Potent Wins**
+
+- Same effect type: keep the one with highest intensity/duration
+- Common in competitive MUDs
+- Prevents overpowered stacking while allowing upgrades
+- Example: Stronger poison replaces weaker poison, but weaker poison doesn't replace
+  stronger
+
+**Option D: Category-Based Stacking**
+
+- Effects grouped by category (buff/debuff/neutral)
+- Same category replaces, different categories stack
+- Most flexible but complex
+- Example: Multiple buffs stack, but new buff replaces old buff; buffs and debuffs stack
+  independently
+
+**Current MythosMUD**: No explicit stacking logic found - effects are simply appended to
+list, allowing unlimited stacking of same effect type
+
+**Decision**: Most potent wins (Option C) with granular categories. Effects grouped by
+granular categories (e.g. poison, stun, lucidity_protection, damage_reduction) rather
+than broad "buff/debuff". Stacking rules apply per category: same category uses "most
+potent wins", different categories stack independently. This allows fine-grained control
+over which effects can coexist.
+
+### 2. Duration Tracking Methods
+
+**Option A: Absolute Timestamp**
+
+- Store `expires_at: datetime` field
+- Calculate remaining duration on read: `remaining = expires_at - now()`
+- Handles server restarts gracefully (no tick counter needed)
+- Works across time zones and server downtime
+- Example: `expires_at: 2026-02-10 14:30:00`
+
+**Option B: Relative Ticks**
+
+- Store `duration: int` (total ticks) and `applied_at_tick: int`
+- Calculate remaining: `remaining = duration - (current_tick - applied_at_tick)`
+- Requires tick counter persistence across server restarts
+- More efficient for tick-based games
+- Example: `duration: 100, applied_at_tick: 5000` → at tick 5050, remaining = 50
+
+**Option C: Remaining Counter**
+
+- Store `remaining: int` that decrements each tick
+- Simplest but requires periodic updates
+- Doesn't handle server restarts well (loses progress)
+- Current MythosMUD approach (mixed with duration)
+- Example: `remaining: 50` → next tick → `remaining: 49`
+
+**Option D: Hybrid Approach**
+
+- Store both `expires_at` (for persistence) and `remaining` (for performance)
+- Use `expires_at` for initial calculation, `remaining` for tick processing
+- Reconcile on load/restart
+
+**Current MythosMUD**: Uses both `duration` (initial) and `remaining` (current), but
+`remaining` is decremented each tick without considering server restarts
+
+**Decision**: Yes, durations survive server restarts. Use relative ticks: store
+`duration` and `applied_at_tick`; persist the game tick counter; remaining =
+duration - (current_tick - applied_at_tick).
+
+### 3. Effect Storage Architecture
+
+**Option A: JSONB Column (Recommended)**
+
+- Single JSONB column storing array of effects
+- Simple queries, atomic updates
+- Good for flexible schemas
+- Supports indexing on JSONB fields
+- PostgreSQL native, efficient for read-heavy workloads
+- Example: `status_effects JSONB DEFAULT '[]'::jsonb`
+
+**Option B: JSON String (Current)**
+
+- Single Text column storing JSON string
+- Simple but limited querying capabilities
+- No indexing support
+- Requires parsing on every read
+- Current MythosMUD approach
+- Example: `status_effects TEXT DEFAULT '[]'`
+
+**Option C: Separate Effects Table**
+
+- Relational table with foreign key to players
+- Better for queries, indexing, cascading deletes
+- More normalized but more complex
+- Requires joins for player data
+- Example: `player_effects` table with `player_id`, `effect_type`, `duration`, etc.
+
+**Option D: Bitvector Flags (CircleMUD style)**
+
+- Boolean flags for predefined effects
+- Very fast checks, limited to ~31-128 effects
+- Not suitable for dynamic effects or effects requiring metadata
+- Example: `affected_by BIGINT` with bit flags
+
+**Current MythosMUD**: JSON string (Text column) - could migrate to JSONB for better
+querying
+
+**Decision**: Separate effects table (Option B). New table (e.g. `player_effects`) with
+player_id, effect_type, category, duration, applied_at_tick, intensity, source, etc.
+Better for queries, indexing, and cascading; use joins when loading player state.
+
+### 4. Event-Driven vs Tick-Based Processing
+
+**Option A: Event-Driven (Evennia/Ranvier)**
+
+- Effects register callbacks for specific game events
+- Effects react to specific triggers (combat, movement, spell casting, etc.)
+- More efficient - only processes when relevant events occur
+- Allows effects to modify event behavior
+- Example: Poison effect registers callback for "on_take_damage" event
+
+**Option B: Tick-Based (Current)**
+
+- Process all effects every game tick
+- Simpler logic, predictable timing
+- May be less efficient for rare effects
+- All effects processed uniformly
+- Current MythosMUD approach
+- Example: Every tick, check all effects and decrement counters
+
+**Option C: Hybrid Approach**
+
+- Tick-based for time-based effects (duration, DoT, HoT)
+- Event-driven for reactive effects (on damage, on spell cast, etc.)
+- Best of both worlds but more complex
+
+**Current MythosMUD**: Tick-based processing in `process_status_effects()` - all effects
+processed every tick
+
+**Decision**: Tick-based only (Option B). Process all effects every game tick. Keep logic
+simple and timing predictable; no event-driven callbacks for now.
+
+### 5. Stat Modification Tracking
+
+**Option A: Store in Effect Metadata**
+
+- Effect contains stat changes in metadata field
+- Revert on expiration by reading metadata
+- Requires effect-specific logic for each stat
+- Example: `effect.metadata = {"strength": +5, "dexterity": -2}`
+
+**Option B: Separate Modification Registry**
+
+- Track stat modifications separately from effects
+- Effects reference modifications by ID
+- Cleaner separation of concerns
+- Easier to query "what modifies strength?"
+- Example: `stat_modifications` table with `effect_id`, `stat_name`, `modifier`
+
+**Option C: Calculate on Demand**
+
+- Don't store modified stats, calculate from base stats + active effects
+- Most accurate but requires calculation on every stat access
+- Example: `current_strength = base_strength + sum(effect.strength_mod for effect in
+active_effects)`
+
+**Current MythosMUD**: Uses StatusEffect with BUFF type for temporary stat mods, but stat
+changes stored separately in stats dict. No automatic reversion on expiration.
+
+**Decision**: Calculate on demand (Option C). Don't store modified stats; compute from
+base stats + active effects each time. If performance becomes an issue, migrate to
+Option B (separate modification registry).
+
+### 6. Effect Scripting and Extensibility
+
+**Option A: Data-Only Effects (Current)**
+
+- Effects are pure data structures
+- Effect behavior hardcoded in processing logic
+- Simple but not extensible
+- Requires code changes for new effect types
+- Current MythosMUD approach
+
+**Option B: Scriptable Effects (Ranvier)**
+
+- Effects can contain scripts/callbacks
+- Effects register for events and execute custom code
+- Highly extensible, allows modding
+- More complex, requires sandboxing for security
+- Example: Effect file contains JavaScript/Python code for custom behavior
+
+**Option C: Effect Templates with Parameters**
+
+- Predefined effect templates with configurable parameters
+- Templates define behavior, parameters customize it
+- Balance between extensibility and security
+- Example: `damage_over_time` template with `damage_per_tick` parameter
+
+**Current MythosMUD**: Data-only effects with hardcoded processing logic
+
+**Decision**: Data-only (Option A). Effects are pure data; behavior is hardcoded in game
+logic. New effect types require code changes. Keeps implementation simple and secure.
+
+### 7. Intensity Scaling
+
+**Current Implementation**: Intensity field (1-10) is defined in StatusEffect model but
+usage in effect processing is unclear.
+
+**Possible Approaches**:
+
+- **Linear Scaling**: Intensity directly multiplies effect strength
+  - Example: `damage = base_damage * intensity`
+- **Exponential Scaling**: Intensity has exponential impact
+  - Example: `damage = base_damage * (intensity ^ 1.5)`
+- **Category-Based**: Different effects use intensity differently
+  - Example: DoT uses linear, stat mods use step function
+- **Duration Scaling**: Intensity affects duration instead of strength
+  - Example: `duration = base_duration * intensity`
+
+**Decision**: Effect-specific. Each effect type defines how it uses intensity (e.g. DoT
+linear, stat mods step function, some ignore it). No single global formula.
+
+## Design Questions for Clarification
+
+The following questions need to be answered to guide the effects system implementation:
+
+1. **Stacking Behavior**: Should identical effect types stack, replace, or use "most potent
+   wins"? Should different effect types always stack?
+
+2. **Duration Persistence**: Should durations survive server restarts? If yes, should we
+   use absolute timestamps or persist the tick counter?
+
+3. **Effect Categories**: Should we group effects (buffs/debuffs/neutral) with different
+   stacking rules per category?
+
+4. **Metadata Storage**: Should stat modifications be stored in effect metadata or tracked
+   separately? How should temporary stat changes be reverted when effects expire?
+
+5. **Event Integration**: Should effects register for specific game events (combat, movement,
+   etc.) or continue processing every tick? Should we support both approaches?
+
+6. **Storage Migration**: Should we migrate from Text JSON to JSONB for better querying and
+   indexing? Or should we use a separate effects table?
+
+7. **Effect Scripting**: Should effects support custom scripts/callbacks like Ranvier, or
+   remain data-only with hardcoded processing logic?
+
+8. **Intensity Scaling**: How should intensity (1-10) affect effect strength? Should it be
+   linear, exponential, or effect-specific?
+
+9. **Effect Expiration**: How should expired effects be cleaned up? Should we clean up
+   immediately on expiration or batch cleanup periodically?
+
+10. **Effect Visibility**: Should players see all active effects, or only certain types?
+    Should effects have visibility levels (hidden, visible, detailed)?
+
+## Design Decisions (Recorded)
+
+Decisions made to guide implementation. Questions not yet decided are marked TBD.
+
+1. **Stacking Behavior**: **Most potent wins (Option C).** Same effect type: keep the
+   instance with highest intensity or longest duration; new applications replace only if
+   they are more potent. Different effect types stack.
+
+2. **Duration Persistence**: **Yes (tick counter).** Durations survive restarts. Store
+   `duration` and `applied_at_tick`; persist game tick counter; remaining = duration -
+   (current_tick - applied_at_tick).
+
+3. **Effect Categories**: **Yes, granular categories.** Use specific categories (e.g.
+   poison, stun, lucidity_protection, damage_reduction) rather than broad buff/debuff.
+   Stacking rules apply per category: same category uses "most potent wins", different
+   categories stack independently.
+
+4. **Metadata Storage**: **Calculate on demand (Option C).** Compute stats from base +
+   active effects on each access. If performance issues arise, migrate to Option B
+   (separate modification registry).
+
+5. **Event Integration**: **Tick-based only (Option B).** Process all effects every game
+   tick; no event-driven callbacks.
+
+6. **Storage Migration**: **Separate effects table (Option B).** New table (e.g.
+   `player_effects`) with player_id, effect_type, category, duration, applied_at_tick,
+   intensity, source, etc. Use joins when loading player state.
+
+7. **Effect Scripting**: **Data-only (Option A).** Effects are pure data; behavior
+   hardcoded in game logic. No custom scripts or callbacks.
+
+8. **Intensity Scaling**: **Effect-specific.** Each effect type defines how it uses
+   intensity (e.g. DoT linear, stat mods step function, some ignore it).
+
+9. **Effect Expiration**: **Immediate cleanup.** Remove the effect as soon as it expires
+   during the tick that processes it. Keeps the list accurate at all times.
+
+10. **Effect Visibility**: **Visibility levels.** Each effect has a visibility level:
+    hidden (not shown), visible (name and maybe duration), detailed (full info: source,
+    intensity, etc.). Levels can be per effect type or per instance. Default: visible.
+
+## Implementation Recommendations
+
+Based on the research and current implementation analysis, here are recommended next
+steps:
+
+1. **Immediate**: Implement stacking logic (recommend "most potent wins" or
+   category-based)
+
+2. **Short-term**: Migrate from Text JSON to JSONB for better querying
+
+3. **Short-term**: Add automatic stat modification reversion on effect expiration
+
+4. **Medium-term**: Implement event-driven processing for reactive effects while keeping
+   tick-based for time-based effects
+
+5. **Medium-term**: Clarify and implement intensity scaling
+
+6. **Long-term**: Consider effect scripting/extensibility if modding support is desired
+
+## References
+
+- Ranvier MUD Effects Documentation: <https://ranviermud.com/coding/effects/>
+- Evennia Attributes Documentation: <https://evennia.com/docs/latest/Components/Attributes.html>
+- CircleMUD AFF Flags: Various mailing list discussions (1995-1997)
+- PostgreSQL JSONB Documentation:
+  <https://www.postgresql.org/docs/16/datatype-json.html>
+- Current MythosMUD Implementation:
+  - `server/models/game.py` - StatusEffect model
+  - `server/models/player.py` - Player model with status_effects storage
+  - `server/app/game_tick_processing.py` - Tick-based effect processing
+  - `server/game/magic/spell_effects.py` - Spell effect application
+
+---
+
+> "The knowledge contained herein represents years of research into the arcane arts of
+> status effect implementation. May it guide our implementation decisions wisely."
+>
+> - Dr. Armitage, Miskatonic University Archives, 2026

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -1839,7 +1839,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MetricsResponse"
+                  "$ref": "#/components/schemas/server__api__monitoring_models__MetricsResponse"
                 }
               }
             }
@@ -2215,7 +2215,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/server__schemas__metrics__MetricsResponse"
+                  "$ref": "#/components/schemas/MetricsResponse"
                 }
               }
             }
@@ -6309,132 +6309,32 @@
       },
       "MetricsResponse": {
         "properties": {
-          "total_movements": {
-            "type": "integer",
-            "title": "Total Movements"
-          },
-          "successful_movements": {
-            "type": "integer",
-            "title": "Successful Movements"
-          },
-          "failed_movements": {
-            "type": "integer",
-            "title": "Failed Movements"
-          },
-          "success_rate": {
-            "type": "number",
-            "title": "Success Rate"
-          },
-          "failure_rate": {
-            "type": "number",
-            "title": "Failure Rate"
-          },
-          "current_concurrent_movements": {
-            "type": "integer",
-            "title": "Current Concurrent Movements"
-          },
-          "max_concurrent_movements": {
-            "type": "integer",
-            "title": "Max Concurrent Movements"
-          },
-          "avg_movement_time_ms": {
-            "type": "number",
-            "title": "Avg Movement Time Ms"
-          },
-          "max_movement_time_ms": {
-            "type": "number",
-            "title": "Max Movement Time Ms"
-          },
-          "min_movement_time_ms": {
-            "type": "number",
-            "title": "Min Movement Time Ms"
-          },
-          "movements_per_second": {
-            "type": "number",
-            "title": "Movements Per Second"
-          },
-          "uptime_seconds": {
-            "type": "number",
-            "title": "Uptime Seconds"
-          },
-          "integrity_checks": {
-            "type": "integer",
-            "title": "Integrity Checks"
-          },
-          "integrity_violations": {
-            "type": "integer",
-            "title": "Integrity Violations"
-          },
-          "integrity_rate": {
-            "type": "number",
-            "title": "Integrity Rate"
-          },
-          "last_movement_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Movement Time"
-          },
-          "last_validation_time": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Validation Time"
-          },
-          "room_occupancy": {
-            "additionalProperties": {
-              "type": "integer"
-            },
+          "metrics": {
+            "additionalProperties": true,
             "type": "object",
-            "title": "Room Occupancy"
-          },
-          "player_movement_counts": {
-            "additionalProperties": {
-              "type": "integer"
-            },
-            "type": "object",
-            "title": "Player Movement Counts"
-          },
-          "timestamp": {
-            "type": "string",
-            "title": "Timestamp"
+            "title": "Metrics",
+            "description": "Comprehensive system metrics including NATS, circuit breaker, and DLQ stats"
           }
         },
         "type": "object",
         "required": [
-          "total_movements",
-          "successful_movements",
-          "failed_movements",
-          "success_rate",
-          "failure_rate",
-          "current_concurrent_movements",
-          "max_concurrent_movements",
-          "avg_movement_time_ms",
-          "max_movement_time_ms",
-          "min_movement_time_ms",
-          "movements_per_second",
-          "uptime_seconds",
-          "integrity_checks",
-          "integrity_violations",
-          "integrity_rate",
-          "last_movement_time",
-          "last_validation_time",
-          "room_occupancy",
-          "player_movement_counts",
-          "timestamp"
+          "metrics"
         ],
         "title": "MetricsResponse",
-        "description": "Response model for movement metrics."
+        "description": "Response model for comprehensive system metrics.",
+        "example": {
+          "metrics": {
+            "circuit_breaker": {
+              "state": "closed"
+            },
+            "dead_letter_queue": {
+              "total_messages": 0
+            },
+            "nats_connection": {
+              "status": "connected"
+            }
+          }
+        }
       },
       "MetricsSummaryResponse": {
         "properties": {
@@ -8816,7 +8716,8 @@
           "trembling",
           "corrupted",
           "delirious",
-          "buff"
+          "buff",
+          "login_warded"
         ],
         "title": "StatusEffectType",
         "description": "Status effects that can be applied to characters."
@@ -9412,34 +9313,134 @@
         "title": "ViewportInfo",
         "description": "Viewport information for map rendering."
       },
-      "server__schemas__metrics__MetricsResponse": {
+      "server__api__monitoring_models__MetricsResponse": {
         "properties": {
-          "metrics": {
-            "additionalProperties": true,
+          "total_movements": {
+            "type": "integer",
+            "title": "Total Movements"
+          },
+          "successful_movements": {
+            "type": "integer",
+            "title": "Successful Movements"
+          },
+          "failed_movements": {
+            "type": "integer",
+            "title": "Failed Movements"
+          },
+          "success_rate": {
+            "type": "number",
+            "title": "Success Rate"
+          },
+          "failure_rate": {
+            "type": "number",
+            "title": "Failure Rate"
+          },
+          "current_concurrent_movements": {
+            "type": "integer",
+            "title": "Current Concurrent Movements"
+          },
+          "max_concurrent_movements": {
+            "type": "integer",
+            "title": "Max Concurrent Movements"
+          },
+          "avg_movement_time_ms": {
+            "type": "number",
+            "title": "Avg Movement Time Ms"
+          },
+          "max_movement_time_ms": {
+            "type": "number",
+            "title": "Max Movement Time Ms"
+          },
+          "min_movement_time_ms": {
+            "type": "number",
+            "title": "Min Movement Time Ms"
+          },
+          "movements_per_second": {
+            "type": "number",
+            "title": "Movements Per Second"
+          },
+          "uptime_seconds": {
+            "type": "number",
+            "title": "Uptime Seconds"
+          },
+          "integrity_checks": {
+            "type": "integer",
+            "title": "Integrity Checks"
+          },
+          "integrity_violations": {
+            "type": "integer",
+            "title": "Integrity Violations"
+          },
+          "integrity_rate": {
+            "type": "number",
+            "title": "Integrity Rate"
+          },
+          "last_movement_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Movement Time"
+          },
+          "last_validation_time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Validation Time"
+          },
+          "room_occupancy": {
+            "additionalProperties": {
+              "type": "integer"
+            },
             "type": "object",
-            "title": "Metrics",
-            "description": "Comprehensive system metrics including NATS, circuit breaker, and DLQ stats"
+            "title": "Room Occupancy"
+          },
+          "player_movement_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Player Movement Counts"
+          },
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp"
           }
         },
         "type": "object",
         "required": [
-          "metrics"
+          "total_movements",
+          "successful_movements",
+          "failed_movements",
+          "success_rate",
+          "failure_rate",
+          "current_concurrent_movements",
+          "max_concurrent_movements",
+          "avg_movement_time_ms",
+          "max_movement_time_ms",
+          "min_movement_time_ms",
+          "movements_per_second",
+          "uptime_seconds",
+          "integrity_checks",
+          "integrity_violations",
+          "integrity_rate",
+          "last_movement_time",
+          "last_validation_time",
+          "room_occupancy",
+          "player_movement_counts",
+          "timestamp"
         ],
         "title": "MetricsResponse",
-        "description": "Response model for comprehensive system metrics.",
-        "example": {
-          "metrics": {
-            "circuit_breaker": {
-              "state": "closed"
-            },
-            "dead_letter_queue": {
-              "total_messages": 0
-            },
-            "nats_connection": {
-              "status": "connected"
-            }
-          }
-        }
+        "description": "Response model for movement metrics."
       },
       "server__schemas__player__MessageResponse": {
         "properties": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,8 @@ max-complexity = 11
 "docs/**/*" = ["F821", "F841", "F811", "B904", "E402"]
 "server/stubs/**/*.pyi" = ["UP046"]  # Stub files use old Generic syntax for compatibility
 "server/main.py" = ["E402"]  # Reason: Imports must come after load_dotenv() to ensure env vars are loaded before any modules that depend on them are imported
+# Alembic requires exact names revision, down_revision, branch_labels, depends_on; cannot use UPPER_CASE
+"server/alembic/versions/*.py" = ["N816"]
 
 [tool.isort]
 profile = "black"

--- a/scripts/pylint.py
+++ b/scripts/pylint.py
@@ -45,10 +45,12 @@ cmd = pylint_cmd + [
     "--max-line-length=120",
     "--disable=all",
     "--enable=E,W,F,C,R",  # E=Error, W=Warning, F=Fatal, C=Convention, R=Refactor
-    # Re-apply disables from .pylintrc after --enable to ensure they're respected
-    # This ensures that rules disabled in .pylintrc (like line-too-long, import-outside-toplevel)
-    # are still disabled even after enabling all categories
-    "--disable=line-too-long,import-outside-toplevel",
+    # Re-apply disables from .pylintrc after --enable so they are not re-enabled by --enable=E,W,F,C,R.
+    # Complexity (R0911-R0915, R0902, R0903, R0904) is handled by ruff C901; see .pylintrc and
+    # docs/LINTING_COMPLEXITY_ALIGNMENT.md.
+    "--disable=line-too-long,import-outside-toplevel,too-many-arguments,too-many-positional-arguments,"
+    "too-many-locals,too-many-statements,too-many-return-statements,too-many-branches,"
+    "too-many-instance-attributes,too-many-public-methods,too-few-public-methods",
     "--output-format=text",
     "--rcfile=.pylintrc",  # Use project pylintrc
 ]

--- a/server/alembic/versions/2026_02_09_add_player_effects_table.py
+++ b/server/alembic/versions/2026_02_09_add_player_effects_table.py
@@ -1,0 +1,66 @@
+"""Add player_effects table (ADR-009 effects system)
+
+Revision ID: add_player_effects_table
+Revises: ensure_item_instance_fks
+Create Date: 2026-02-09
+
+"""
+# Module name comes from filename; Alembic uses date-prefixed migration filenames by convention.
+# pylint: disable=invalid-name
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+# Alembic is available at runtime when running `alembic upgrade`; linters may not see it.
+from alembic import op  # pyright: ignore[reportMissingImports]  # pylint: disable=import-error
+from sqlalchemy.dialects import postgresql
+
+# Revision identifiers, used by Alembic (required names; see file-level invalid-name disable).
+revision = "add_player_effects_table"
+down_revision = "ensure_item_instance_fks"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create player_effects table and indexes (ADR-009 effects system)."""
+    op.create_table(
+        "player_effects",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "player_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("players.player_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("effect_type", sa.String(length=64), nullable=False),
+        sa.Column("category", sa.String(length=64), nullable=False),
+        sa.Column("duration", sa.Integer(), nullable=False),
+        sa.Column("applied_at_tick", sa.Integer(), nullable=False),
+        sa.Column("intensity", sa.Integer(), nullable=False, server_default=sa.text("1")),
+        sa.Column("source", sa.String(length=128), nullable=True),
+        sa.Column(
+            "visibility_level",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'visible'"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_player_effects_player_id", "player_effects", ["player_id"])
+    op.create_index("ix_player_effects_effect_type", "player_effects", ["effect_type"])
+    op.create_index("ix_player_effects_category", "player_effects", ["category"])
+
+
+def downgrade() -> None:
+    """Drop player_effects table and indexes."""
+    op.drop_index("ix_player_effects_category", table_name="player_effects")
+    op.drop_index("ix_player_effects_effect_type", table_name="player_effects")
+    op.drop_index("ix_player_effects_player_id", table_name="player_effects")
+    op.drop_table("player_effects")

--- a/server/models/__init__.py
+++ b/server/models/__init__.py
@@ -19,6 +19,7 @@ from .item import ItemComponentState, ItemInstance, ItemPrototype
 from .lucidity import LucidityAdjustmentLog, LucidityCooldown, LucidityExposureState, PlayerLucidity
 from .npc import NPCDefinition, NPCDefinitionType, NPCRelationship, NPCSpawnRule
 from .player import Player, PlayerExploration, PlayerInventory
+from .player_effect import PlayerEffect
 from .player_spells import PlayerSpell
 from .spell import Spell, SpellEffectType, SpellMaterial, SpellRangeType, SpellSchool, SpellTargetType
 from .spell_db import SpellDB
@@ -66,6 +67,7 @@ __all__ = [
     "SpellRangeType",
     "SpellEffectType",
     "SpellMaterial",
+    "PlayerEffect",
     "PlayerSpell",
     "SpellDB",
     "Zone",

--- a/server/models/game.py
+++ b/server/models/game.py
@@ -40,6 +40,8 @@ class StatusEffectType(StrEnum):
     CORRUPTED = "corrupted"
     DELIRIOUS = "delirious"
     BUFF = "buff"
+    # Effects system (ADR-009): game-entry warded (login grace period)
+    LOGIN_WARDED = "login_warded"
 
 
 class PositionState(StrEnum):

--- a/server/models/player.py
+++ b/server/models/player.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
         LucidityExposureState,
         PlayerLucidity,
     )
+    from .player_effect import PlayerEffect
     from .player_spells import PlayerSpell
     from .user import User
 
@@ -105,6 +106,10 @@ class Player(Base):
     user: Mapped["User"] = relationship("User", back_populates="players", overlaps="player")
     spells: Mapped[list["PlayerSpell"]] = relationship(
         "PlayerSpell", back_populates="player", cascade="all, delete-orphan"
+    )
+    # Effects system (ADR-009): persistent tick-based effects in player_effects table
+    player_effects: Mapped[list["PlayerEffect"]] = relationship(
+        "PlayerEffect", back_populates="player", cascade="all, delete-orphan"
     )
 
     # Profession - add index for queries filtering by profession

--- a/server/models/player_effect.py
+++ b/server/models/player_effect.py
@@ -1,0 +1,57 @@
+"""
+Player effect model for the effects system (ADR-009).
+
+Persistent, tick-based status effects stored in a separate player_effects table.
+"""
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from .player import Player
+
+
+class PlayerEffect(Base):
+    """
+    Persistent player effect (status effect) with tick-based duration.
+
+    Table: player_effects. Per ADR-009: separate table, duration and applied_at_tick
+    for remaining = duration - (current_tick - applied_at_tick).
+    """
+
+    __tablename__ = "player_effects"
+    __table_args__ = {"extend_existing": True}
+
+    id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        default=lambda: str(uuid4()),
+    )
+    player_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("players.player_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    effect_type: Mapped[str] = mapped_column(String(length=64), nullable=False, index=True)
+    category: Mapped[str] = mapped_column(String(length=64), nullable=False, index=True)
+    duration: Mapped[int] = mapped_column(Integer, nullable=False)  # ticks
+    applied_at_tick: Mapped[int] = mapped_column(Integer, nullable=False)
+    intensity: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    source: Mapped[str | None] = mapped_column(String(length=128), nullable=True)
+    visibility_level: Mapped[str] = mapped_column(String(length=32), nullable=False, default="visible")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(),
+        default=lambda: datetime.now(UTC).replace(tzinfo=None),
+        nullable=False,
+    )
+
+    # Relationship back to Player
+    player: Mapped["Player"] = relationship("Player", back_populates="player_effects")

--- a/server/persistence/repositories/__init__.py
+++ b/server/persistence/repositories/__init__.py
@@ -4,12 +4,14 @@ from .container_repository import ContainerRepository
 from .experience_repository import ExperienceRepository
 from .health_repository import HealthRepository
 from .item_repository import ItemRepository
+from .player_effect_repository import PlayerEffectRepository
 from .player_repository import PlayerRepository
 from .profession_repository import ProfessionRepository
 from .room_repository import RoomRepository
 
 __all__ = [
     "PlayerRepository",
+    "PlayerEffectRepository",
     "RoomRepository",
     "HealthRepository",
     "ExperienceRepository",

--- a/server/persistence/repositories/player_effect_repository.py
+++ b/server/persistence/repositories/player_effect_repository.py
@@ -1,0 +1,224 @@
+"""
+Player effect repository for the effects system (ADR-009).
+
+Async persistence for player_effects table: add, delete, get active, has_effect,
+remaining_ticks, and expire effects by current tick.
+"""
+
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.exc import SQLAlchemyError
+
+from server.database import get_session_maker
+from server.exceptions import DatabaseError
+from server.models.player_effect import PlayerEffect
+from server.structured_logging.enhanced_logging_config import get_logger
+from server.utils.error_logging import create_error_context, log_and_raise
+
+logger = get_logger(__name__)
+
+
+class PlayerEffectRepository:
+    """Repository for player_effects table (tick-based persistent effects)."""
+
+    async def add_effect(
+        self,
+        player_id: UUID | str,
+        effect_type: str,
+        category: str,
+        duration: int,
+        applied_at_tick: int,
+        intensity: int = 1,
+        source: str | None = None,
+        visibility_level: str = "visible",
+    ) -> str:
+        """
+        Add a player effect. Returns the effect id (UUID string).
+
+        Args:
+            player_id: Player UUID
+            effect_type: Effect type (e.g. login_warded)
+            category: Category (e.g. entry_ward)
+            duration: Duration in ticks
+            applied_at_tick: Tick when effect was applied
+            intensity: Intensity (default 1)
+            source: Optional source string
+            visibility_level: visible, hidden, or detailed
+
+        Returns:
+            Effect id (UUID string)
+
+        Raises:
+            DatabaseError: If insert fails
+        """
+        context = create_error_context()
+        context.metadata["operation"] = "add_effect"
+        context.metadata["player_id"] = str(player_id)
+        context.metadata["effect_type"] = effect_type
+
+        try:
+            session_maker = get_session_maker()
+            async with session_maker() as session:
+                effect = PlayerEffect(
+                    player_id=str(player_id),
+                    effect_type=effect_type,
+                    category=category,
+                    duration=duration,
+                    applied_at_tick=applied_at_tick,
+                    intensity=intensity,
+                    source=source,
+                    visibility_level=visibility_level,
+                )
+                session.add(effect)
+                await session.commit()
+                await session.refresh(effect)
+                effect_id = effect.id
+                logger.debug(
+                    "Added player effect",
+                    player_id=str(player_id),
+                    effect_type=effect_type,
+                    effect_id=effect_id,
+                )
+                return effect_id
+        except (SQLAlchemyError, OSError) as e:
+            log_and_raise(
+                DatabaseError,
+                f"Database error adding player effect: {e}",
+                context=context,
+                details={"player_id": str(player_id), "effect_type": effect_type, "error": str(e)},
+                user_friendly="Failed to add player effect",
+            )
+
+    async def delete_effect(self, effect_id: UUID | str) -> None:
+        """Delete an effect by id. No-op if not found."""
+        context = create_error_context()
+        context.metadata["operation"] = "delete_effect"
+        context.metadata["effect_id"] = str(effect_id)
+
+        try:
+            session_maker = get_session_maker()
+            async with session_maker() as session:
+                await session.execute(delete(PlayerEffect).where(PlayerEffect.id == str(effect_id)))
+                await session.commit()
+                logger.debug("Deleted player effect", effect_id=str(effect_id))
+        except (SQLAlchemyError, OSError) as e:
+            log_and_raise(
+                DatabaseError,
+                f"Database error deleting player effect: {e}",
+                context=context,
+                details={"effect_id": str(effect_id), "error": str(e)},
+                user_friendly="Failed to delete player effect",
+            )
+
+    def _remaining_ticks(self, duration: int, applied_at_tick: int, current_tick: int) -> int:
+        """Compute remaining ticks. Effect is active when result > 0."""
+        return duration - (current_tick - applied_at_tick)
+
+    async def get_active_effects_for_player(self, player_id: UUID | str, current_tick: int) -> list[PlayerEffect]:
+        """Return effects where remaining_ticks > 0. Order by applied_at_tick."""
+        context = create_error_context()
+        context.metadata["operation"] = "get_active_effects_for_player"
+        context.metadata["player_id"] = str(player_id)
+
+        try:
+            session_maker = get_session_maker()
+            async with session_maker() as session:
+                result = await session.execute(
+                    select(PlayerEffect)
+                    .where(PlayerEffect.player_id == str(player_id))
+                    .order_by(PlayerEffect.applied_at_tick)
+                )
+                rows = list(result.scalars().all())
+                # Filter by remaining > 0
+                active = [r for r in rows if self._remaining_ticks(r.duration, r.applied_at_tick, current_tick) > 0]
+                return active
+        except (SQLAlchemyError, OSError) as e:
+            log_and_raise(
+                DatabaseError,
+                f"Database error getting active effects: {e}",
+                context=context,
+                details={"player_id": str(player_id), "error": str(e)},
+                user_friendly="Failed to get active effects",
+            )
+
+    async def get_effects_expiring_this_tick(self, current_tick: int) -> list[tuple[str, str]]:
+        """
+        Find effects that expire this tick (remaining <= 0), return (player_id, effect_type).
+        Caller should then delete/expire them (we delete in expire_effects_for_tick).
+        """
+        context = create_error_context()
+        context.metadata["operation"] = "get_effects_expiring_this_tick"
+        context.metadata["current_tick"] = current_tick
+
+        try:
+            session_maker = get_session_maker()
+            async with session_maker() as session:
+                result = await session.execute(select(PlayerEffect))
+                rows = result.scalars().all()
+                expiring = [
+                    (r.player_id, r.effect_type)
+                    for r in rows
+                    if self._remaining_ticks(r.duration, r.applied_at_tick, current_tick) <= 0
+                ]
+                return expiring
+        except (SQLAlchemyError, OSError) as e:
+            log_and_raise(
+                DatabaseError,
+                f"Database error getting expiring effects: {e}",
+                context=context,
+                details={"current_tick": current_tick, "error": str(e)},
+                user_friendly="Failed to get expiring effects",
+            )
+
+    async def expire_effects_for_tick(self, current_tick: int) -> list[tuple[str, str]]:
+        """
+        Delete all effects that have expired at current_tick and return their (player_id, effect_type).
+        """
+        expiring = await self.get_effects_expiring_this_tick(current_tick)
+        if not expiring:
+            return []
+
+        context = create_error_context()
+        context.metadata["operation"] = "expire_effects_for_tick"
+        context.metadata["current_tick"] = current_tick
+
+        try:
+            session_maker = get_session_maker()
+            async with session_maker() as session:
+                # Delete rows where applied_at_tick + duration <= current_tick
+                stmt = delete(PlayerEffect).where(PlayerEffect.applied_at_tick + PlayerEffect.duration <= current_tick)
+                await session.execute(stmt)
+                await session.commit()
+                logger.debug(
+                    "Expired player effects for tick",
+                    current_tick=current_tick,
+                    count=len(expiring),
+                    expired=expiring,
+                )
+                return expiring
+        except (SQLAlchemyError, OSError) as e:
+            log_and_raise(
+                DatabaseError,
+                f"Database error expiring effects: {e}",
+                context=context,
+                details={"current_tick": current_tick, "error": str(e)},
+                user_friendly="Failed to expire effects",
+            )
+
+    async def has_effect(self, player_id: UUID | str, effect_type: str, current_tick: int) -> bool:
+        """Return True if player has an active effect of the given type."""
+        active = await self.get_active_effects_for_player(player_id, current_tick)
+        return any(e.effect_type == effect_type for e in active)
+
+    async def get_effect_remaining_ticks(
+        self, player_id: UUID | str, effect_type: str, current_tick: int
+    ) -> int | None:
+        """
+        Return remaining ticks for the first matching active effect, or None if none.
+        """
+        active = await self.get_active_effects_for_player(player_id, current_tick)
+        for e in active:
+            if e.effect_type == effect_type:
+                return self._remaining_ticks(e.duration, e.applied_at_tick, current_tick)
+        return None

--- a/server/tests/unit/models/test_game_enums.py
+++ b/server/tests/unit/models/test_game_enums.py
@@ -71,6 +71,7 @@ def test_status_effect_type_enum_all_types():
         "corrupted",
         "delirious",
         "buff",
+        "login_warded",  # ADR-009 effects system
     }
     actual_types = {t.value for t in StatusEffectType}
     assert actual_types == expected_types

--- a/server/tests/unit/persistence/test_player_effect_repository.py
+++ b/server/tests/unit/persistence/test_player_effect_repository.py
@@ -1,0 +1,220 @@
+"""
+Unit tests for PlayerEffectRepository (ADR-009 effects system).
+
+Tests add_effect, delete_effect, get_active_effects_for_player, has_effect,
+get_effect_remaining_ticks, and expire_effects_for_tick.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from server.models.player_effect import PlayerEffect
+from server.persistence.repositories.player_effect_repository import PlayerEffectRepository
+
+
+@pytest.fixture
+def repo():
+    """Create PlayerEffectRepository instance."""
+    return PlayerEffectRepository()
+
+
+@pytest.fixture
+def player_id():
+    """Sample player UUID."""
+    return uuid.uuid4()
+
+
+def _make_effect(
+    player_id_str: str,
+    effect_type: str = "login_warded",
+    duration: int = 100,
+    applied_at_tick: int = 0,
+) -> MagicMock:
+    """Build a mock PlayerEffect with given fields."""
+    e = MagicMock(spec=PlayerEffect)
+    e.player_id = player_id_str
+    e.effect_type = effect_type
+    e.duration = duration
+    e.applied_at_tick = applied_at_tick
+    e.id = str(uuid.uuid4())
+    return e
+
+
+@pytest.mark.asyncio
+async def test_add_effect_returns_id(repo, player_id):
+    """add_effect persists effect and returns effect id."""
+    mock_session = AsyncMock()
+    mock_session.commit = AsyncMock()
+    effect_id = str(uuid.uuid4())
+
+    def set_id_on_refresh(obj):
+        obj.id = effect_id
+
+    mock_session.refresh = AsyncMock(side_effect=set_id_on_refresh)
+    mock_session.add = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("server.persistence.repositories.player_effect_repository.get_session_maker") as m:
+        m.return_value = MagicMock()
+        m.return_value.return_value = mock_session
+
+        result = await repo.add_effect(
+            player_id,
+            "login_warded",
+            "entry_ward",
+            duration=100,
+            applied_at_tick=50,
+        )
+
+        assert result == effect_id
+        mock_session.add.assert_called_once()
+        mock_session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_effect(repo):
+    """delete_effect removes effect by id."""
+    effect_id = str(uuid.uuid4())
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("server.persistence.repositories.player_effect_repository.get_session_maker") as m:
+        m.return_value = MagicMock()
+        m.return_value.return_value = mock_session
+
+        await repo.delete_effect(effect_id)
+
+        mock_session.execute.assert_called_once()
+        mock_session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_active_effects_for_player_filters_by_remaining(repo, player_id):
+    """get_active_effects_for_player returns only effects with remaining_ticks > 0."""
+    pid_str = str(player_id)
+    effect_active = _make_effect(pid_str, "login_warded", duration=100, applied_at_tick=10)
+    effect_expired = _make_effect(pid_str, "poisoned", duration=5, applied_at_tick=0)
+    current_tick = 50
+    # remaining for effect_active: 100 - (50 - 10) = 60 > 0
+    # remaining for effect_expired: 5 - (50 - 0) = -45 <= 0
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [effect_active, effect_expired]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("server.persistence.repositories.player_effect_repository.get_session_maker") as m:
+        m.return_value = MagicMock()
+        m.return_value.return_value = mock_session
+
+        active = await repo.get_active_effects_for_player(player_id, current_tick)
+
+        assert len(active) == 1
+        assert active[0].effect_type == "login_warded"
+
+
+@pytest.mark.asyncio
+async def test_has_effect_true(repo, player_id):
+    """has_effect returns True when player has active effect of type."""
+    pid_str = str(player_id)
+    effect = _make_effect(pid_str, "login_warded", duration=100, applied_at_tick=0)
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [effect]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("server.persistence.repositories.player_effect_repository.get_session_maker") as m:
+        m.return_value = MagicMock()
+        m.return_value.return_value = mock_session
+
+        assert await repo.has_effect(player_id, "login_warded", current_tick=10) is True
+
+
+@pytest.mark.asyncio
+async def test_has_effect_false(repo, player_id):
+    """has_effect returns False when no active effect of type."""
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("server.persistence.repositories.player_effect_repository.get_session_maker") as m:
+        m.return_value = MagicMock()
+        m.return_value.return_value = mock_session
+
+        assert await repo.has_effect(player_id, "login_warded", current_tick=1000) is False
+
+
+@pytest.mark.asyncio
+async def test_get_effect_remaining_ticks(repo, player_id):
+    """get_effect_remaining_ticks returns duration - (current_tick - applied_at_tick)."""
+    pid_str = str(player_id)
+    effect = _make_effect(pid_str, "login_warded", duration=100, applied_at_tick=20)
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [effect]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("server.persistence.repositories.player_effect_repository.get_session_maker") as m:
+        m.return_value = MagicMock()
+        m.return_value.return_value = mock_session
+
+        remaining = await repo.get_effect_remaining_ticks(player_id, "login_warded", current_tick=50)
+        assert remaining == 70  # 100 - (50 - 20)
+
+
+@pytest.mark.asyncio
+async def test_get_effect_remaining_ticks_none(repo, player_id):
+    """get_effect_remaining_ticks returns None when no matching effect."""
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("server.persistence.repositories.player_effect_repository.get_session_maker") as m:
+        m.return_value = MagicMock()
+        m.return_value.return_value = mock_session
+
+        assert await repo.get_effect_remaining_ticks(player_id, "login_warded", current_tick=0) is None
+
+
+@pytest.mark.asyncio
+async def test_expire_effects_for_tick_returns_expired_and_deletes(repo):
+    """expire_effects_for_tick returns (player_id, effect_type) and deletes rows."""
+    effect1 = _make_effect("p1", "login_warded", duration=10, applied_at_tick=0)
+    effect2 = _make_effect("p2", "poisoned", duration=5, applied_at_tick=0)
+    current_tick = 20
+    get_result = MagicMock()
+    get_result.scalars.return_value.all.return_value = [effect1, effect2]
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(side_effect=[get_result, None])
+    mock_session.commit = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    ctx = MagicMock()
+    ctx.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    ctx.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("server.persistence.repositories.player_effect_repository.get_session_maker") as m:
+        m.return_value = ctx
+
+        expired = await repo.expire_effects_for_tick(current_tick)
+
+        assert set(expired) == {("p1", "login_warded"), ("p2", "poisoned")}
+        assert mock_session.commit.called


### PR DESCRIPTION
- Created ADR-009 documenting the architecture for a unified effects system, detailing stacking, duration, and processing rules.
- Developed a separate implementation plan for the effects system, including tasks for creating the `player_effects` table and integrating it with existing game mechanics.
- Updated various components to display active effects in the UI, enhancing player experience and interaction.
- Added database migration scripts to establish the new `player_effects` table, ensuring persistence of effects across game sessions.

This commit lays the groundwork for a robust effects system, improving gameplay dynamics and aligning with the MythosMUD's evolving architecture.

Signed-off-by: arkanwolfshade <23161760+arkanwolfshade@users.noreply.github.com>

# Research Submission to Miskatonic Archives

*"Document your findings clearly, test thoroughly, and guard against both bugs and eldritch horrors."*

---

## 📚 Description

<!-- What does this PR do? What problem does it solve? -->

**Closes**: #

---

## 🔬 Type of Change

[ ] ✨ Feature

- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔒 Security
- [ ] ⚡ Performance

---

## 🧪 Testing

[ ] Added/updated unit tests

- [ ] All tests pass (`make test`)
- [ ] Test coverage ≥80%
- [ ] Manually tested in local environment

**How to test:**
<!-- Brief steps for reviewers to verify the changes -->

---

## 🔒 Security Checklist

[ ] No secrets/credentials committed

- [ ] Input validation & sanitization implemented
- [ ] SQL queries use parameterized statements
- [ ] Enhanced logging used (no f-strings, no `context=`)
- [ ] No sensitive data in logs

**Security impact**: [ ] None [ ] Low [ ] Medium [ ] High

---

## ✅ Pre-Submission

[ ] Tests pass (`make test`)

- [ ] Linting passes (`make lint`)
- [ ] Code follows style guides (ruff, ESLint)
- [ ] Documentation updated
- [ ] Commit messages follow conventions
- [ ] Branch created from latest `dev`

---

## 📸 Screenshots

<!-- For UI changes, include before/after screenshots -->

---

## 📝 Notes

<!-- Breaking changes, dependencies, or anything else reviewers should know -->

---

*"May your code be sound and your tests comprehensive."* — Miskatonic CS Faculty
