### PR TITLE
chore: add Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,38 @@ single-file consolidated reference usable outside Cursor, see the repo root [CLA
 - Client ui-v2 real-time UI is driven from WebSocket events through the event projector under
   `client/src/components/ui-v2/eventLog` into `GameState`; desyncs between log lines and meters often mean missing
   merges in the projector, not only panel components
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Command | Port | Notes |
+|---------|---------|------|-------|
+| FastAPI backend | `uv run uvicorn server.main:app --host 0.0.0.0 --port 54731` | 54731 | Loads `.env.local` automatically |
+| React client | `cd client && npm run dev` | 5173 | Vite dev server |
+| PostgreSQL 16 | `sudo service postgresql start` | 5432 | User `postgres`, password in `.env.local` |
+| NATS server | auto-started by backend via `NATS_SERVER_PATH` | 4222 | Binary at `/usr/local/bin/nats-server` |
+
+### Environment setup gotchas
+
+- **pg_hba.conf**: PostgreSQL must be configured for `md5` password auth (not default `peer`) for the
+  `postgres` user on local and host connections. The backup is at `/etc/postgresql/16/main/pg_hba.conf.bak`.
+- **Database schemas**: The DDL file hardcodes a `SET search_path` to the dev schema name. When applying
+  to unit/e2e databases, the schema inside was renamed to match the target database name. Future DDL
+  re-applications may need the same schema rename treatment.
+- **`.env.local`**: Must be copied from `env.local.example` (not `env.unit_test.example`). The
+  `NATS_SERVER_PATH` must point to `/usr/local/bin/nats-server` on Linux.
+- **Makefile PowerShell targets**: `make test-server` calls PowerShell scripts
+  (`scripts/apply_procedures.ps1`, etc.) which require `pwsh`. On Linux Cloud VMs without PowerShell,
+  run server tests directly: `uv run pytest server/tests/ -m "not integration"`.
+- **Client test failures**: A few client tests in `useRespawnHandlers.test.ts` have a pre-existing URL
+  mismatch (expects relative URL, gets absolute). These are not caused by environment setup.
+
+### Quick-reference commands
+
+- **Lint server**: `uv run ruff check server/`
+- **Lint client**: `cd client && npx eslint .`
+- **Test server (unit only)**: `uv run pytest server/tests/ -m "not integration"`
+- **Test client**: `cd client && npx vitest run`
+- **Run backend dev**: `uv run uvicorn server.main:app --host 0.0.0.0 --port 54731`
+- **Run client dev**: `cd client && npm run dev`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Research Submission to Miskatonic Archives

> "Document your findings clearly, test thoroughly, and guard against both bugs and eldritch horrors."

---

## Description

Adds Cursor Cloud specific instructions to `AGENTS.md` for future cloud agents to use when setting up the
MythosMUD development environment on Linux-based Cloud VMs.

**What changes does this PR make?**
- Adds `## Cursor Cloud specific instructions` section to `AGENTS.md` with service overview table, environment
  setup gotchas, and quick-reference commands for lint/test/build/run.

**What problem does it solve?**
Future cloud agents need documented setup caveats (pg_hba.conf auth, schema naming, .env.local config,
PowerShell script limitations) to avoid repeating discovery work.

---

## Type of Change

- [x] Documentation

---

## Testing

- [x] All tests pass (`make test` - server unit tests pass; client has pre-existing failures)
- [x] Manually tested in local environment
- [x] Linting passes (ruff, eslint)

**How to test:**
Server unit tests: `uv run pytest server/tests/ -m "not integration"` (7797 passed)
Client tests: `cd client && npx vitest run` (3 pre-existing failures in useRespawnHandlers)

---

## Security Checklist

- [x] No secrets/credentials committed
- [x] No sensitive data in logs

**Security impact**: None

---

## Pre-Submission

- [x] Linting passes (`make lint` equivalent)
- [x] Code follows style guides
- [x] Documentation updated as needed
- [x] Commit messages follow conventions
- [x] Branch created from latest `main`

---

> "May your code be sound and your tests comprehensive." -- Miskatonic CS Faculty
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19948529-db81-413d-987d-054f38e39815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19948529-db81-413d-987d-054f38e39815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

