### PR TITLE
fix(security): clear open CodeQL and in-repo Scorecard alerts

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,16 +9,20 @@
 name: "Dependency Review"
 on: [pull_request]
 
-# dependency-submission API requires contents:write; id-token for OIDC when uploading snapshots.
+# Scorecard TokenPermissions: top-level stays read; elevate write only on this job for snapshot upload.
 permissions:
-  contents: write
-  id-token: write
-  pull-requests: write
+  contents: read
 
 jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    # contents:write — Component Detection dependency-submission API only.
+    # id-token — OIDC when uploading snapshots; pull-requests — failure comment summary.
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
     # Opt into Node 24 for JS actions until dependency-review-action ships node24 (see GitHub changelog).
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/Dockerfile.github-runner
+++ b/Dockerfile.github-runner
@@ -91,16 +91,11 @@ COPY pyproject.toml uv.lock ./
 COPY client/package.json client/package-lock.json ./client/
 COPY client/scripts ./client/scripts/
 WORKDIR /workspace/client
-# Human reader: use npm ci for reproducible builds, fallback to npm install if lock file is out of sync.
-# AI reader: npm ci requires lock file to be in sync with package.json. If it fails, clean and reinstall.
+# Human reader: npm ci only — lockfile integrity hashes pin the tree (OpenSSF Scorecard PinnedDependencies).
+# AI reader: do not fall back to unpinned npm install; fail the image build if lock is out of sync.
 # --legacy-peer-deps: resolve eslint 10 vs eslint-plugin-react-hooks peer conflict (eslint-plugin requires ^3-9).
-# Diagnostic: set -x prints each command before it runs so we see exactly where it hangs.
 RUN set -x && echo "[npm] Starting npm ci..." && \
-    (npm ci --legacy-peer-deps --loglevel verbose || \
-    (echo "[npm] npm ci failed, running fallback npm install..." && \
-    rm -rf node_modules package-lock.json && \
-    echo "[npm] Starting npm install..." && \
-    npm install --legacy-peer-deps --loglevel verbose))
+    npm ci --legacy-peer-deps --loglevel verbose
 
 # Copy full source after dependency layers are cached.
 WORKDIR /workspace

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -197,6 +197,17 @@ For detailed information about our security architecture and implementation:
 
 ## Known Security Considerations
 
+### OpenSSF Scorecard (org-process findings)
+
+In-repo Scorecard and CodeQL findings are fixed in code when feasible. These Scorecard
+checks remain **owner/org process** (not resolved by repository source changes alone):
+
+- **Branch-Protection**: tighten GitHub rulesets (admin enforcement, required approvers,
+  dismiss stale reviews, last-push approval) in repository settings.
+- **CII-Best-Practices**: apply for / maintain the OpenSSF Best Practices badge.
+- **Fuzzing**: adopt a fuzzing program (for example OSS-Fuzz or project atheris targets)
+  when bandwidth allows.
+
 ### Current Environment
 
 **MVP Status**: MythosMUD is currently in beta development

--- a/scripts/ci/quality_fragmentation_guard.py
+++ b/scripts/ci/quality_fragmentation_guard.py
@@ -76,14 +76,15 @@ def check_fragmentation_trends(
 
 
 def emit_results(summary: dict[str, object], failures: list[str], warnings: list[str]) -> int:
-    # Avoid logging full summary payloads to keep potentially sensitive paths/details out of plaintext logs.
+    # CodeQL py/clear-text-logging-sensitive-data: never print full guard strings (paths).
+    # Counts + stable digests are enough for CI; full text stays in returned lists for callers/tests.
     print(f"Quality guard summary: hard_fail_reasons={len(failures)}, warnings={len(warnings)}, metrics={len(summary)}")
-    for warning in warnings:
-        print(f"[WARNING] {warning}")
-        print(f"::warning::{warning}")
-    for failure in failures:
-        print(f"[ERROR] {failure}")
-        print(f"::error::{failure}")
+    if warnings:
+        print(f"[WARNING] quality_guard warnings={len(warnings)}")
+        print(f"::warning title=QualityGuard::warnings={len(warnings)}")
+    if failures:
+        print(f"[ERROR] quality_guard hard_fail_reasons={len(failures)}")
+        print(f"::error title=QualityGuard::hard_fail_reasons={len(failures)}")
     return 1 if failures else 0
 
 

--- a/server/alias_storage.py
+++ b/server/alias_storage.py
@@ -79,9 +79,9 @@ class AliasStorage:
         Human: reject path separators / traversal in player_name before touching disk.
         AI: CodeQL py/path-injection — basename + realpath/commonpath containment (recognized barriers).
         """
-        safe_name = validate_player_name(player_name)
-        if not safe_name:
+        if not isinstance(player_name, str) or not player_name:
             raise ValueError("Player name is required for alias storage path")
+        safe_name = validate_player_name(player_name)
         # Drop any directory components; CodeQL treats basename as a path sanitizer.
         safe_name = os.path.basename(safe_name)
         if ".." in safe_name or os.sep in safe_name or (os.altsep is not None and os.altsep in safe_name):

--- a/server/alias_storage.py
+++ b/server/alias_storage.py
@@ -77,16 +77,20 @@ class AliasStorage:
         """Get the file path for a player's aliases.
 
         Human: reject path separators / traversal in player_name before touching disk.
-        AI: CodeQL py/path-injection — validate then resolve under storage_dir only.
+        AI: CodeQL py/path-injection — basename + realpath/commonpath containment (recognized barriers).
         """
         safe_name = validate_player_name(player_name)
         if not safe_name:
             raise ValueError("Player name is required for alias storage path")
-        storage_root = self.storage_dir.resolve()
-        candidate = (storage_root / f"{safe_name}_aliases.json").resolve()
-        if not candidate.is_relative_to(storage_root):
+        # Drop any directory components; CodeQL treats basename as a path sanitizer.
+        safe_name = os.path.basename(safe_name)
+        if ".." in safe_name or os.sep in safe_name or (os.altsep is not None and os.altsep in safe_name):
+            raise ValueError("Invalid player name for alias path")
+        base_dir = os.path.realpath(str(self.storage_dir))
+        candidate = os.path.realpath(os.path.join(base_dir, f"{safe_name}_aliases.json"))
+        if os.path.commonpath([base_dir, candidate]) != base_dir:
             raise ValueError("Alias path escapes storage directory")
-        return candidate
+        return Path(candidate)
 
     def _load_alias_data(self, player_name: str) -> dict[str, Any]:
         """Load alias data from JSON file."""

--- a/server/alias_storage.py
+++ b/server/alias_storage.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 
 from .models import Alias
 from .structured_logging.enhanced_logging_config import get_logger
+from .validators.security_validator import validate_player_name
 
 logger = get_logger(__name__)
 
@@ -73,8 +74,19 @@ class AliasStorage:
         self.storage_dir.mkdir(parents=True, exist_ok=True)
 
     def _get_alias_file_path(self, player_name: str) -> Path:
-        """Get the file path for a player's aliases."""
-        return self.storage_dir / f"{player_name}_aliases.json"
+        """Get the file path for a player's aliases.
+
+        Human: reject path separators / traversal in player_name before touching disk.
+        AI: CodeQL py/path-injection — validate then resolve under storage_dir only.
+        """
+        safe_name = validate_player_name(player_name)
+        if not safe_name:
+            raise ValueError("Player name is required for alias storage path")
+        storage_root = self.storage_dir.resolve()
+        candidate = (storage_root / f"{safe_name}_aliases.json").resolve()
+        if not candidate.is_relative_to(storage_root):
+            raise ValueError("Alias path escapes storage directory")
+        return candidate
 
     def _load_alias_data(self, player_name: str) -> dict[str, Any]:
         """Load alias data from JSON file."""

--- a/server/tests/unit/game/test_player_service.py
+++ b/server/tests/unit/game/test_player_service.py
@@ -475,13 +475,17 @@ async def test_get_online_players(player_service, mock_persistence):
 
 
 @pytest.mark.asyncio
-async def test_delete_player_success(player_service, mock_persistence):
+async def test_delete_player_success(player_service, mock_persistence, tmp_path, monkeypatch):
     """Test delete_player() successfully deletes player."""
     player_id = uuid.uuid4()
+    mock_player = MagicMock()
+    mock_player.name = "TestPlayer"
+    mock_persistence.get_player_by_id = AsyncMock(return_value=mock_player)
     mock_persistence.delete_player = AsyncMock(return_value=True)
+    monkeypatch.setenv("ALIASES_DIR", str(tmp_path))
     success, message = await player_service.delete_player(player_id)
     assert success is True
-    assert "deleted" in message.lower() or "success" in message.lower()
+    assert "deleted" in message.lower() or "TestPlayer" in message
 
 
 @pytest.mark.asyncio

--- a/server/tests/unit/test_alias_storage.py
+++ b/server/tests/unit/test_alias_storage.py
@@ -78,7 +78,7 @@ def test_get_alias_file_path(alias_storage):
     """Test _get_alias_file_path returns correct path."""
     path = alias_storage._get_alias_file_path("TestPlayer")
     assert path.name == "TestPlayer_aliases.json"
-    assert path.parent == alias_storage.storage_dir.resolve()
+    assert path.parent == Path(os.path.realpath(alias_storage.storage_dir))
 
 
 def test_get_alias_file_path_rejects_traversal(alias_storage, temp_storage_dir):

--- a/server/tests/unit/test_alias_storage.py
+++ b/server/tests/unit/test_alias_storage.py
@@ -78,7 +78,23 @@ def test_get_alias_file_path(alias_storage):
     """Test _get_alias_file_path returns correct path."""
     path = alias_storage._get_alias_file_path("TestPlayer")
     assert path.name == "TestPlayer_aliases.json"
-    assert path.parent == alias_storage.storage_dir
+    assert path.parent == alias_storage.storage_dir.resolve()
+
+
+def test_get_alias_file_path_rejects_traversal(alias_storage, temp_storage_dir):
+    """Path-injection: traversal and separators must not escape storage_dir."""
+    with pytest.raises(ValueError):
+        alias_storage._get_alias_file_path("../outside")
+    with pytest.raises(ValueError):
+        alias_storage._get_alias_file_path("foo/bar")
+    with pytest.raises(ValueError):
+        alias_storage._get_alias_file_path("foo\\bar")
+    with pytest.raises(ValueError):
+        alias_storage._get_alias_file_path("")
+    # No alias file created outside the storage root.
+    assert list(temp_storage_dir.rglob("*")) == []
+    outside = temp_storage_dir.parent / "outside_aliases.json"
+    assert not outside.exists()
 
 
 def test_load_alias_data_nonexistent_file(alias_storage):

--- a/server/tests/unit/test_quality_fragmentation_guard.py
+++ b/server/tests/unit/test_quality_fragmentation_guard.py
@@ -27,6 +27,7 @@ class _QualityGuardModule(Protocol):
     _scan_changed_files: object
     is_safe_git_ref: object
     _parse_lizard_output: object
+    emit_results: Callable[[dict[str, object], list[str], list[str]], int]
 
 
 class _QualityTrendsModule(Protocol):
@@ -302,6 +303,19 @@ def test_run_cmd_decodes_subprocess_output_as_utf8(monkeypatch: pytest.MonkeyPat
     assert captured.get("encoding") == "utf-8"
     assert captured.get("errors") == "replace"
     assert captured.get("text") is True
+
+
+def test_emit_results_does_not_print_failure_or_warning_bodies(capsys: pytest.CaptureFixture[str]) -> None:
+    """Regression: CodeQL clear-text logging — emit counts only, never path-bearing bodies."""
+    emit_results = _load_guard_module().emit_results
+    sensitive = "C:/secret/private/key.pem failed lizard CCN"
+    code = emit_results({"m": 1}, [sensitive], [sensitive])
+    assert code == 1
+    out = capsys.readouterr().out
+    assert "hard_fail_reasons=1" in out
+    assert "warnings=1" in out
+    assert sensitive not in out
+    assert "private/key.pem" not in out
 
 
 def test_git_show_file_decodes_subprocess_output_as_utf8(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Fix CodeQL `py/path-injection` in `alias_storage` via `validate_player_name` + resolve-under-storage_dir
- Fix CodeQL `py/clear-text-logging-sensitive-data` in quality fragmentation guard (counts only)
- Fix Scorecard PinnedDependencies: `npm ci` only in `Dockerfile.github-runner` (drop unpinned `npm install` fallback)
- Fix Scorecard TokenPermissions: top-level `contents: read`; elevate write on the dependency-review job only
- Document org-process Scorecard leftovers (#14 BranchProtection, #19 CII, #21 Fuzzing) in SECURITY.md

## Test plan
- [x] Unit tests: alias storage path traversal + emit_results redaction
- [ ] CodeQL analysis closes alerts #143–#146
- [ ] Scorecard closes #137 and #142
- [ ] Dependency Review still green on this PR
- [ ] Leave #14 / #19 / #21 for org settings (optional dismiss after merge)